### PR TITLE
Eager load kuroko2 lib directory

### DIFF
--- a/lib/kuroko2/engine.rb
+++ b/lib/kuroko2/engine.rb
@@ -18,6 +18,7 @@ module Kuroko2
     end
 
     config.autoload_paths << root.join('lib')
+    config.eager_load_paths << root.join('lib')
 
     initializer "kuroko2.configuration" do |app|
       URI.parse(Kuroko2.config.url).tap do |url|


### PR DESCRIPTION
Kuroko2-app generated below command cannot launch executor, scheduler and processor in production environment.

```
$ rails new kuroko2_example --database=mysql --skip-turbolinks --skip-javascript -m https://raw.githubusercontent.com/cookpad/kuroko2/master/app_template.rb
```

```
$ ./bin/rails runner -e production 'Kuroko2::Servers::CommandExecutor.new.run'
Please specify a valid ruby command or the path of a script to run.
Run 'bin/rails runner -h' for help.
```


## Development environment (default)
In development environment, I can launch servers. 

```
$ ./bin/rails runner 'Kuroko2::Servers::CommandExecutor.new.run'
I, [2016-10-21T15:25:52.129422 #72510]  INFO -- : [P674.local-0] Start worker
I, [2016-10-21T15:25:52.182034 #72511]  INFO -- : [P674.local-1] Start worker
I, [2016-10-21T15:25:52.185623 #72512]  INFO -- : [P674.local-2] Start worker
I, [2016-10-21T15:25:52.188994 #72513]  INFO -- : [P674.local-3] Start worker
I, [2016-10-21T15:25:52.191987 #72514]  INFO -- : [P674.local-4] Start worker
I, [2016-10-21T15:25:52.195354 #72515]  INFO -- : [P674.local-5] Start worker
```

## Development environment (`config.cache_classes = true` and `config.eager_load = true`)
- It cannot launch with cache classes and eager load

```
$ ./bin/rails runner 'Kuroko2::Servers::CommandExecutor.new.run'
Please specify a valid ruby command or the path of a script to run.
Run 'bin/rails runner -h' for help.
$ ./bin/rails c
Loading development environment (Rails 5.0.0.1)
irb(main):001:0> Kuroko2::Servers::CommandExecutor
NameError: uninitialized constant Kuroko2::Servers
        from (irb):1
        from /Users/sunao-komuro/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-5.0.0.1/lib/rails/commands/console.rb:65:in `start'
        from /Users/sunao-komuro/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-5.0.0.1/lib/rails/commands/console_helper.rb:9:in `start'
        from /Users/sunao-komuro/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
        from /Users/sunao-komuro/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
        from /Users/sunao-komuro/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
        from ./bin/rails:9:in `require'
        from ./bin/rails:9:in `<main>'
```

## Development environment (`config.cache_classes = true` and `config.eager_load = true` with my branch https://github.com/hogelog/kuroko2-engine/tree/eager_load_paths)
I can launch servers.

```
$ ./bin/rails runner 'Kuroko2::Servers::CommandExecutor.new.run'
I, [2016-10-21T15:47:33.061562 #86911]  INFO -- : [P674.local-0] Start worker
I, [2016-10-21T15:47:33.095761 #86912]  INFO -- : [P674.local-1] Start worker
I, [2016-10-21T15:47:33.099514 #86913]  INFO -- : [P674.local-2] Start worker
I, [2016-10-21T15:47:33.103920 #86914]  INFO -- : [P674.local-3] Start worker
I, [2016-10-21T15:47:33.109596 #86915]  INFO -- : [P674.local-4] Start worker
I, [2016-10-21T15:47:33.110606 #86916]  INFO -- : [P674.local-5] Start worker
```

@eisuke How about this PR?