### PR TITLE
s/Time.now/Time.current/

### DIFF
--- a/app/controllers/kuroko2/job_definition_stats_controller.rb
+++ b/app/controllers/kuroko2/job_definition_stats_controller.rb
@@ -33,7 +33,7 @@ class Kuroko2::JobDefinitionStatsController < Kuroko2::ApplicationController
   private
 
   def set_period
-    @end_at   = Time.now
+    @end_at   = Time.current
 
     @start_at =
       case params[:period]

--- a/app/controllers/kuroko2/job_timelines_controller.rb
+++ b/app/controllers/kuroko2/job_timelines_controller.rb
@@ -39,7 +39,7 @@ class Kuroko2::JobTimelinesController < Kuroko2::ApplicationController
   end
 
   def set_period
-    @end_at   = Time.now
+    @end_at   = Time.current
 
     @start_at =
       case params[:period]

--- a/app/models/kuroko2/execution.rb
+++ b/app/models/kuroko2/execution.rb
@@ -37,12 +37,12 @@ class Kuroko2::Execution < Kuroko2::ApplicationRecord
   end
 
   def finish(output:, exit_status:)
-    update!(output: output, exit_status: exit_status, finished_at: Time.now)
+    update!(output: output, exit_status: exit_status, finished_at: Time.current)
     job_definition.memory_expectancy.calculate!
   end
 
   def finish_by_signal(output:, term_signal:)
-    update!(output: output, term_signal: term_signal, finished_at: Time.now)
+    update!(output: output, term_signal: term_signal, finished_at: Time.current)
     job_definition.memory_expectancy.calculate!
   end
 

--- a/app/models/kuroko2/job_instance.rb
+++ b/app/models/kuroko2/job_instance.rb
@@ -63,7 +63,7 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
   end
 
   def execution_minutes
-    (((error_at || canceled_at || finished_at || Time.now) - created_at).to_f / 60).round(2)
+    (((error_at || canceled_at || finished_at || Time.current) - created_at).to_f / 60).round(2)
   end
 
   def status
@@ -98,7 +98,7 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
         token.script                 = self.script
         token.context                = {
           meta: {
-            launched_time:       Time.now,
+            launched_time:       Time.current,
             job_definition_id:   definition.id,
             job_definition_name: definition.name,
             job_instance_id:     id,

--- a/app/models/kuroko2/job_schedule.rb
+++ b/app/models/kuroko2/job_schedule.rb
@@ -18,7 +18,7 @@ class Kuroko2::JobSchedule < Kuroko2::ApplicationRecord
   validates :cron, format: { with: CRON_FORMAT }, uniqueness: { scope: :job_definition_id }
   validate :validate_cron_schedule
 
-  def next(now = Time.now)
+  def next(now = Time.current)
     if 1.month.ago(now).future?
       Kuroko2.logger.warn("Exceeds the time of criteria #{now}. (Up to 1 month since)")
       return

--- a/lib/kuroko2/command/monitor.rb
+++ b/lib/kuroko2/command/monitor.rb
@@ -68,9 +68,9 @@ module Kuroko2
 
       def log_memory_consumption?(execution)
         if @intervals[execution.id]
-          @intervals[execution.id].reached?(Time.now)
+          @intervals[execution.id].reached?(Time.current)
         else # first time
-          @intervals[execution.id] = MemoryConsumptionLog::Interval.new(Time.now)
+          @intervals[execution.id] = MemoryConsumptionLog::Interval.new(Time.current)
           true
         end
       end

--- a/lib/kuroko2/execution_logger/cloud_watch_logs.rb
+++ b/lib/kuroko2/execution_logger/cloud_watch_logs.rb
@@ -79,7 +79,7 @@ module Kuroko2
     private
 
     def timestamp_now
-      (Time.now.to_f * 1000).to_i # milliseconds
+      (Time.current.to_f * 1000).to_i # milliseconds
     end
 
     def create_log_stream

--- a/lib/kuroko2/workflow/scheduler.rb
+++ b/lib/kuroko2/workflow/scheduler.rb
@@ -17,7 +17,7 @@ module Kuroko2
             begin
               @processing.set!
               JobSchedule.transaction do
-                now = Time.now
+                now = Time.current
                 last_scheduled_time = Tick.fetch_then_update(now)
                 JobSchedule.launch_scheduled_jobs!(last_scheduled_time, now)
               end

--- a/lib/kuroko2/workflow/task/execute.rb
+++ b/lib/kuroko2/workflow/task/execute.rb
@@ -78,7 +78,7 @@ module Kuroko2
         def process_timeout_if_needed(execution)
           timeout = token.context['TIMEOUT'].to_i
 
-          if timeout > 0 && ((execution.created_at + timeout.minutes) < Time.now) && execution.pid
+          if timeout > 0 && ((execution.created_at + timeout.minutes) < Time.current) && execution.pid
             hostname = Worker.executing(execution.id).try(:hostname)
             if hostname
               ProcessSignal.create!(pid: execution.pid, hostname: hostname)
@@ -114,7 +114,7 @@ module Kuroko2
 
         def notify_long_elapsed_time_if_needed(execution)
           if available_notify_long_elapsed_time?(execution) && elapsed_expected_time?(execution)
-            token.context['EXPECTED_TIME_NOTIFIED_AT'] = Time.now
+            token.context['EXPECTED_TIME_NOTIFIED_AT'] = Time.current
             Notifier.notify(:long_elapsed_time, token.job_instance)
 
             message = "(token #{token.uuid}) The running time is longer than #{expected_time} minutes!"

--- a/lib/kuroko2/workflow/task/sleep.rb
+++ b/lib/kuroko2/workflow/task/sleep.rb
@@ -4,7 +4,7 @@ module Kuroko2
       class Sleep < Base
         def execute
           if (time = token.context['SLEEP'])
-            if Time.now.to_i > time
+            if Time.current.to_i > time
               token.context.delete('SLEEP')
 
               :next
@@ -12,7 +12,7 @@ module Kuroko2
               :pass
             end
           else
-            token.context['SLEEP'] = Time.now.to_i + option.to_i
+            token.context['SLEEP'] = Time.current.to_i + option.to_i
 
             :pass
           end

--- a/lib/kuroko2/workflow/task/wait.rb
+++ b/lib/kuroko2/workflow/task/wait.rb
@@ -61,7 +61,7 @@ module Kuroko2
         private
 
         # ex. wait: 100/daily 200/daily
-        def parse_option(option, start_at: Time.now)
+        def parse_option(option, start_at: Time.current)
           raise_assertion_error unless option
 
           wait_option = { "jobs" => [], "timeout" => 60.minutes.to_i / 1.minute }
@@ -113,7 +113,7 @@ module Kuroko2
           end
         end
 
-        def period_to_time(period, at: Time.now)
+        def period_to_time(period, at: Time.current)
           case period
           when "hourly"
             [at.beginning_of_hour, at.end_of_hour]

--- a/spec/command/monitor_spec.rb
+++ b/spec/command/monitor_spec.rb
@@ -15,7 +15,7 @@ module Kuroko2::Command
       let(:sent_mail) { ActionMailer::Base.deliveries.last }
 
       context 'not running process' do
-        let!(:execution) { create(:execution, token: token, worker: worker, started_at: Time.now, finished_at: nil, pid: pid) }
+        let!(:execution) { create(:execution, token: token, worker: worker, started_at: Time.current, finished_at: nil, pid: pid) }
         let(:monitor) { Kuroko2::Command::Monitor.new(hostname: hostname, worker_id: 1) }
 
         subject! { 15.times { monitor.execute } }
@@ -44,7 +44,7 @@ module Kuroko2::Command
     end
 
     describe 'memory consumption monitoring' do
-      let!(:execution) { create(:execution, token: token, worker: worker, started_at: Time.now, finished_at: nil, pid: pid) }
+      let!(:execution) { create(:execution, token: token, worker: worker, started_at: Time.current, finished_at: nil, pid: pid) }
       let(:monitor) { Kuroko2::Command::Monitor.new(hostname: hostname, worker_id: 1) }
       before do
         allow(monitor).to receive(:check_process_absence).and_return(true)

--- a/spec/execution_logger/cloud_watch_logs_spec.rb
+++ b/spec/execution_logger/cloud_watch_logs_spec.rb
@@ -9,7 +9,7 @@ describe Kuroko2::ExecutionLogger::CloudWatchLogs do
   end
 
   describe '#put_logs' do
-    let(:events) { [{ timestamp: Time.now.to_i * 1000, message: 'hello' }] }
+    let(:events) { [{ timestamp: Time.current.to_i * 1000, message: 'hello' }] }
     let(:response) { double('Response', data: { next_sequence_token: 'abc' })}
 
     let(:send_parameters) do

--- a/spec/factories/execution_factory.rb
+++ b/spec/factories/execution_factory.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     job_instance { token.job_instance if token }
     context { token.context if token }
 
-    started_at { Time.now }
-    finished_at { Time.now }
+    started_at { Time.current }
+    finished_at { Time.current }
   end
 end

--- a/spec/models/job_instance_spec.rb
+++ b/spec/models/job_instance_spec.rb
@@ -83,7 +83,7 @@ describe Kuroko2::JobInstance do
     let(:definition) { create(:job_definition) }
 
     context 'with finished_at present' do
-      let(:finished_at) { Time.now }
+      let(:finished_at) { Time.current }
 
       it 'returns "success"' do
         expect(instance.status).to eq('success')
@@ -91,7 +91,7 @@ describe Kuroko2::JobInstance do
     end
 
     context 'with canceled_at present' do
-      let(:canceled_at) { Time.now }
+      let(:canceled_at) { Time.current }
 
       it 'returns "canceled"' do
         expect(instance.status).to eq('canceled')
@@ -99,7 +99,7 @@ describe Kuroko2::JobInstance do
     end
 
     context 'with error_at present' do
-      let(:error_at) { Time.now }
+      let(:error_at) { Time.current }
 
       it 'returns "error"' do
         expect(instance.status).to eq('error')

--- a/spec/models/memory_consumption_log_spec.rb
+++ b/spec/models/memory_consumption_log_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Kuroko2::MemoryConsumptionLog do
-  around {|example| Timecop.freeze(Time.now) { example.run } }
+  around {|example| Timecop.freeze(Time.current) { example.run } }
 
   describe described_class::Interval do
     describe '#reached?' do
       let(:interval) { described_class.new(base, count) }
-      let(:base) { Time.now }
+      let(:base) { Time.current }
 
       context 'count = 0 and 2 seconds since' do
         let(:count) { 0 }
@@ -29,7 +29,7 @@ RSpec.describe Kuroko2::MemoryConsumptionLog do
 
     describe '#next' do
       it 'returns count-up-ed Interval' do
-        a = described_class.new(Time.now)
+        a = described_class.new(Time.current)
         b = a.next
         expect(b).to be_a(described_class)
 
@@ -39,7 +39,7 @@ RSpec.describe Kuroko2::MemoryConsumptionLog do
     end
 
     it 'behaves as certain period interval with #reached? and #next' do
-      a = described_class.new(Time.now, 100)
+      a = described_class.new(Time.current, 100)
       expect(a.reached?(29.minutes.since.to_time)).to be_falsy
       expect(a.reached?(31.minutes.since.to_time)).to be_truthy
       b = a.next

--- a/spec/requests/api/job_instances_spec.rb
+++ b/spec/requests/api/job_instances_spec.rb
@@ -29,7 +29,7 @@ describe 'job_instances' do
     end
 
     context 'with job_instance succeeded' do
-      let(:instance) { create(:job_instance, job_definition: definition, finished_at: Time.now, error_at: nil, canceled_at: nil) }
+      let(:instance) { create(:job_instance, job_definition: definition, finished_at: Time.current, error_at: nil, canceled_at: nil) }
 
       it 'returns "success" as status' do
         get "/v1/definitions/#{definition.id}/instances/#{instance.id}", params: {}, env: env

--- a/spec/workflow/task/execute_spec.rb
+++ b/spec/workflow/task/execute_spec.rb
@@ -98,7 +98,7 @@ module Kuroko2::Workflow::Task
         end
 
         context 'When EXPECTED_TIME_NOTIFIED_AT is now' do
-          let(:notified_time) { Time.now }
+          let(:notified_time) { Time.current }
 
           it 'does not alert warnings' do
             expect(Kuroko2::Workflow::Notifier).not_to receive(:notify)

--- a/spec/workflow/task/wait_spec.rb
+++ b/spec/workflow/task/wait_spec.rb
@@ -13,7 +13,7 @@ module Kuroko2::Workflow::Task
       context 'with valid syntax' do
         let(:definition) { create(:job_definition, script: "wait: #{option}") }
         let(:instance) do
-          create(:job_instance, job_definition: definition, created_at: Time.now).tap do |instance|
+          create(:job_instance, job_definition: definition, created_at: Time.current).tap do |instance|
             instance.tokens.destroy
           end
         end
@@ -123,7 +123,7 @@ module Kuroko2::Workflow::Task
       end
 
       context 'with invalid syntax' do
-        let(:token) { build(:token, job_instance: build(:job_instance, created_at: Time.now)) }
+        let(:token) { build(:token, job_instance: build(:job_instance, created_at: Time.current)) }
 
         context 'with invalid job_definition_id' do
           let(:option) { 'AAA/daily' }


### PR DESCRIPTION
To as be unaffected by the local system time zone.

@cookpad/dev-infra 👓 