### PR TITLE
Fix Kuroko2.logger

### DIFF
--- a/lib/kuroko2.rb
+++ b/lib/kuroko2.rb
@@ -11,7 +11,7 @@ require "kuroko2/configuration"
 module Kuroko2
   class << self
     def logger
-      @logger ||= defined?(Rails) && Rails.env.test? ? Rails.logger : Util::Logger.new($stdout)
+      @logger ||= defined?(Rails) && Rails.env.test? ? Rails.logger : Kuroko2::Util::Logger.new($stdout)
     end
 
     def logger=(logger)


### PR DESCRIPTION
`Kuroko2.logger` cannot call with current kuroko2 master branch.

```
$ ./bin/rails c
Loading development environment (Rails 5.0.0.1)
irb(main):001:0> Kuroko2.logger
NameError: uninitialized constant Util
        from /Users/hogelog/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/kuroko2-b6232e6dc484/lib/kuroko2.rb:14:in `logger'
        from (irb):1
        from /Users/hogelog/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console.rb:65:in `start'
        from /Users/hogelog/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console_helper.rb:9:in `start'
        from /Users/hogelog/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
        from /Users/hogelog/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
        from /Users/hogelog/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
        from ./bin/rails:4:in `require'
        from ./bin/rails:4:in `<main>'
```

Maybe https://github.com/cookpad/kuroko2/pull/5 changes make this error.

@eisuke ping
