### PR TITLE
Change `Notify success event to Slack/Hipchat` option to `Notify all event to Slack/Hipchat`

### DIFF
--- a/app/controllers/kuroko2/api/job_instances_controller.rb
+++ b/app/controllers/kuroko2/api/job_instances_controller.rb
@@ -19,10 +19,11 @@ class Kuroko2::Api::JobInstancesController < Kuroko2::Api::ApplicationController
       raise HTTP::Forbidden.new("#{definition.name} is not allowed to be executed via API")
     end
 
-    instance = definition.job_instances.create(
+    instance = definition.create_instance(
       script: definition.script.prepend(env_script),
+      launched_by: "instances API (#{basic_user_name})"
     )
-    instance.logs.info("Launched by instances API (#{basic_user_name})")
+
     Kuroko2::Api::JobInstanceResource.new(instance)
   end
 

--- a/app/controllers/kuroko2/job_instances_controller.rb
+++ b/app/controllers/kuroko2/job_instances_controller.rb
@@ -9,19 +9,13 @@ class Kuroko2::JobInstancesController < Kuroko2::ApplicationController
   end
 
   def create
+    creation_params = { launched_by: current_user.name }
     if params[:job_definition].present?
-      @instance = @definition.job_instances.create(params.require(:job_definition).permit(:script))
-    else
-      @instance = @definition.job_instances.create
+      creation_params.merge!(params.require(:job_definition).permit(:script).to_h.symbolize_keys)
     end
 
-    if @instance
-      @instance.logs.info("Launched by #{current_user.name}.")
-
-      redirect_to job_definition_job_instance_path(@definition, @instance)
-    else
-      raise HTTP::BadRequest
-    end
+    @instance = @definition.create_instance(creation_params)
+    redirect_to job_definition_job_instance_path(@definition, @instance)
   end
 
   def show

--- a/app/controllers/kuroko2/job_instances_controller.rb
+++ b/app/controllers/kuroko2/job_instances_controller.rb
@@ -37,11 +37,7 @@ class Kuroko2::JobInstancesController < Kuroko2::ApplicationController
 
   def destroy
     if @instance.cancelable?
-      ActiveRecord::Base.transaction { @instance.cancel }
-
-      message = "This job was canceled by #{current_user.name}."
-      @instance.logs.warn(message)
-      Kuroko2.logger.warn(message)
+      ActiveRecord::Base.transaction { @instance.cancel(by: current_user.name) }
     end
 
     redirect_to job_definition_job_instance_path(@definition, @instance)
@@ -54,7 +50,7 @@ class Kuroko2::JobInstancesController < Kuroko2::ApplicationController
         execution.update_column(:execution_id, nil) if execution
       end
 
-      @instance.cancel
+      @instance.cancel(by: current_user.name)
     end
 
     message = "Force canceled by #{current_user.name}."

--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -93,6 +93,16 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
     end
   end
 
+  def create_instance(script: nil, launched_by:, token: nil )
+    message = "Launched by #{launched_by}"
+
+    if token.present?
+      message = "(token #{token.uuid}) #{message}"
+    end
+
+    job_instances.create!(script: script, log_message: message)
+  end
+
   private
 
   def confirm_active_instances

--- a/app/models/kuroko2/job_instance.rb
+++ b/app/models/kuroko2/job_instance.rb
@@ -54,7 +54,8 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
     message = "This job was canceled by #{by}."
     self.logs.warn(message)
     Kuroko2.logger.warn(message)
-    Kuroko2::Workflow::Notifier.notify(:cancellation, self)
+
+    Kuroko2::Workflow::Notifier.notify(:cancellation, self) if job_definition.hipchat_notify_finished?
   end
 
   # Log given value if it is greater than stored one.
@@ -128,7 +129,7 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
       self.logs.warn(message)
       Kuroko2.logger.warn(message)
 
-      Kuroko2::Workflow::Notifier.notify(:cancellation, self)
+      Kuroko2::Workflow::Notifier.notify(:cancellation, self) if job_definition.notify_cancellation
     end
   end
 end

--- a/app/models/kuroko2/job_instance.rb
+++ b/app/models/kuroko2/job_instance.rb
@@ -54,7 +54,6 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
     message = "This job was canceled by #{by}."
     self.logs.warn(message)
     Kuroko2.logger.warn(message)
-    Kuroko2::Workflow::Notifier.notify(:cancellation, self)
   end
 
   # Log given value if it is greater than stored one.

--- a/app/models/kuroko2/job_instance.rb
+++ b/app/models/kuroko2/job_instance.rb
@@ -54,6 +54,7 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
     message = "This job was canceled by #{by}."
     self.logs.warn(message)
     Kuroko2.logger.warn(message)
+    Kuroko2::Workflow::Notifier.notify(:cancellation, self)
   end
 
   # Log given value if it is greater than stored one.

--- a/app/models/kuroko2/job_instance.rb
+++ b/app/models/kuroko2/job_instance.rb
@@ -43,10 +43,15 @@ class Kuroko2::JobInstance < Kuroko2::ApplicationRecord
     tokens.first.try(:cancelable?)
   end
 
-  def cancel
+  def cancel(by:)
     self.tokens.destroy(*self.tokens)
     self.executions.destroy(*self.executions)
     self.touch(:canceled_at)
+
+    message = "This job was canceled by #{by}."
+    self.logs.warn(message)
+    Kuroko2.logger.warn(message)
+    Kuroko2::Workflow::Notifier.notify(:cancellation, self)
   end
 
   # Log given value if it is greater than stored one.

--- a/app/models/kuroko2/job_schedule.rb
+++ b/app/models/kuroko2/job_schedule.rb
@@ -81,11 +81,8 @@ class Kuroko2::JobSchedule < Kuroko2::ApplicationRecord
         elsif suspend_times.include?(time)
           Kuroko2.logger.info("Skipped schedule suspended \"##{definition.id} #{definition.name}\" that is scheduled at #{I18n.l(time, format: :short)} by `#{schedule.cron}`")
         else
-          message = "Launched \"##{definition.id} #{definition.name}\" that is scheduled at #{I18n.l(time, format: :short)} by `#{schedule.cron}`"
-          Kuroko2.logger.info(message)
-
-          instance = definition.job_instances.create
-          instance.logs.info(message)
+          launched_by = "\"##{definition.id} #{definition.name}\" that is scheduled at #{I18n.l(time, format: :short)} by `#{schedule.cron}`"
+          definition.create_instance(launched_by: launched_by)
         end
       end
     end

--- a/app/views/kuroko2/job_definitions/_form.html.slim
+++ b/app/views/kuroko2/job_definitions/_form.html.slim
@@ -39,7 +39,7 @@
     .checkbox
       label
         = form.check_box :hipchat_notify_finished
-        ' Notify success event to Slack/Hipchat
+        ' Notify all event to Slack/Hipchat
 
     .checkbox
       label

--- a/lib/autoload/kuroko2/workflow/engine.rb
+++ b/lib/autoload/kuroko2/workflow/engine.rb
@@ -30,7 +30,7 @@ module Kuroko2
 
           Kuroko2.logger.info(message)
 
-          Notifier.notify(:working, token.job_instance)
+          Notifier.notify(:retring, token.job_instance)
         end
       end
 
@@ -49,7 +49,7 @@ module Kuroko2
 
           Kuroko2.logger.info(message)
 
-          Notifier.notify(:working, token.job_instance)
+          Notifier.notify(:skipping, token.job_instance)
         end
       end
 

--- a/lib/autoload/kuroko2/workflow/engine.rb
+++ b/lib/autoload/kuroko2/workflow/engine.rb
@@ -30,7 +30,7 @@ module Kuroko2
 
           Kuroko2.logger.info(message)
 
-          Notifier.notify(:retring, token.job_instance)
+          Notifier.notify(:retrying, token.job_instance)
         end
       end
 

--- a/lib/autoload/kuroko2/workflow/notifier/concerns/chat_message_builder.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/concerns/chat_message_builder.rb
@@ -20,8 +20,8 @@ module Kuroko2
             "Launched '#{@definition.name}'"
           end
 
-          def retring_text
-            "Retring the current task in '#{@definition.name}'"
+          def retrying_text
+            "Retrying the current task in '#{@definition.name}'"
           end
 
           def skipping_text

--- a/lib/autoload/kuroko2/workflow/notifier/concerns/chat_message_builder.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/concerns/chat_message_builder.rb
@@ -16,6 +16,14 @@ module Kuroko2
             "Finished to execute '#{@definition.name}'"
           end
 
+          def retring_text
+            "Retring the current task in '#{@definition.name}'"
+          end
+
+          def skipping_text
+            "Skipping the current task in '#{@definition.name}'"
+          end
+
           def long_elapsed_time_text
             "The running time is longer than expected '#{@definition.name}'."
           end

--- a/lib/autoload/kuroko2/workflow/notifier/concerns/chat_message_builder.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/concerns/chat_message_builder.rb
@@ -16,6 +16,10 @@ module Kuroko2
             "Finished to execute '#{@definition.name}'"
           end
 
+          def launched_text
+            "Launched '#{@definition.name}'"
+          end
+
           def retring_text
             "Retring the current task in '#{@definition.name}'"
           end

--- a/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
@@ -13,6 +13,16 @@ module Kuroko2
           @message_builder = Workflow::Notifier::Concerns::ChatMessageBuilder.new(instance)
         end
 
+        def notify_launch
+          if @definition.hipchat_notify_finished?
+            message = build_message(level: 'SUCCESS', text: message_builder.launched_text)
+            message << "<br>"
+            message << @instance.logs.last(2).first.message
+
+            send_to_hipchat(message, color: 'yellow')
+          end
+        end
+
         def notify_retring
           if @definition.hipchat_notify_finished
             message = build_message(level: 'SUCCESS', text: message_builder.retring_text)

--- a/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
@@ -44,7 +44,7 @@ module Kuroko2
         end
 
         def notify_cancellation
-          if @definition.notify_cancellation
+          if @definition.notify_cancellation || @definition.hipchat_notify_finished?
             message = build_message(level: 'WARNING', text: message_builder.failure_text)
             message << "<br>"
             message << @instance.logs.select{ |log| log.level == 'WARN' }.last.try!(:message)

--- a/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
@@ -17,7 +17,7 @@ module Kuroko2
           if @definition.hipchat_notify_finished?
             message = build_message(level: 'SUCCESS', text: message_builder.launched_text)
             message << "<br>"
-            message << @instance.logs.last(2).first.message
+            message << @instance.logs.select{ |log| log.level == 'INFO' }.last.try!(:message)
 
             send_to_hipchat(message, color: 'yellow')
           end
@@ -47,7 +47,7 @@ module Kuroko2
           if @definition.notify_cancellation
             message = build_message(level: 'WARNING', text: message_builder.failure_text)
             message << "<br>"
-            message << @instance.logs.last(2).first.message
+            message << @instance.logs.select{ |log| log.level == 'WARN' }.last.try!(:message)
 
             send_to_hipchat(message, color: 'yellow')
           end

--- a/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
@@ -23,9 +23,9 @@ module Kuroko2
           end
         end
 
-        def notify_retring
+        def notify_retrying
           if @definition.hipchat_notify_finished
-            message = build_message(level: 'SUCCESS', text: message_builder.retring_text)
+            message = build_message(level: 'SUCCESS', text: message_builder.retrying_text)
             message << "<br>"
             message << @instance.logs.last(2).first.message
 

--- a/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/hipchat.rb
@@ -13,8 +13,24 @@ module Kuroko2
           @message_builder = Workflow::Notifier::Concerns::ChatMessageBuilder.new(instance)
         end
 
-        def notify_working
-          # do nothing
+        def notify_retring
+          if @definition.hipchat_notify_finished
+            message = build_message(level: 'SUCCESS', text: message_builder.retring_text)
+            message << "<br>"
+            message << @instance.logs.last(2).first.message
+
+            send_to_hipchat(message, color: 'yellow')
+          end
+        end
+
+        def notify_skipping
+          if @definition.hipchat_notify_finished
+            message = build_message(level: 'SUCCESS', text: message_builder.skipping_text)
+            message << "<br>"
+            message << @instance.logs.last(2).first.message
+
+            send_to_hipchat(message, color: 'yellow')
+          end
         end
 
         def notify_cancellation

--- a/lib/autoload/kuroko2/workflow/notifier/mail.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/mail.rb
@@ -11,7 +11,7 @@ module Kuroko2
           # do nothing
         end
 
-        def notify_retring
+        def notify_retrying
           # do nothing
         end
 

--- a/lib/autoload/kuroko2/workflow/notifier/mail.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/mail.rb
@@ -7,7 +7,11 @@ module Kuroko2
           @definition   = job_instance.job_definition
         end
 
-        def notify_working
+        def notify_retring
+          # do nothing
+        end
+
+        def notify_skipping
           # do nothing
         end
 

--- a/lib/autoload/kuroko2/workflow/notifier/mail.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/mail.rb
@@ -7,6 +7,10 @@ module Kuroko2
           @definition   = job_instance.job_definition
         end
 
+        def notify_launch
+          # do nothing
+        end
+
         def notify_retring
           # do nothing
         end

--- a/lib/autoload/kuroko2/workflow/notifier/slack.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/slack.rb
@@ -19,6 +19,16 @@ module Kuroko2
           @webhook_url = Kuroko2.config.notifiers.slack.webhook_url
         end
 
+        def notify_launch
+          if @definition.hipchat_notify_finished?
+            send_attachment_message_to_slack(
+              level: 'INFO',
+              text: message_builder.launched_text,
+              body: @instance.logs.last(2).first.message,
+            )
+          end
+        end
+
         def notify_retring
           if @definition.hipchat_notify_finished?
             send_attachment_message_to_slack(

--- a/lib/autoload/kuroko2/workflow/notifier/slack.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/slack.rb
@@ -9,6 +9,7 @@ module Kuroko2
           FAILURE  = 'danger'
           CRITICAL = 'danger'
           SUCCESS  = 'good'
+          INFO     = '#439FE0'
         end
 
         def initialize(instance)
@@ -18,8 +19,24 @@ module Kuroko2
           @webhook_url = Kuroko2.config.notifiers.slack.webhook_url
         end
 
-        def notify_working
-          # do nothing
+        def notify_retring
+          if @definition.hipchat_notify_finished?
+            send_attachment_message_to_slack(
+              level: 'INFO',
+              text: message_builder.retring_text,
+              body: @instance.logs.last(2).first.message,
+            )
+          end
+        end
+
+        def notify_skipping
+          if @definition.hipchat_notify_finished?
+            send_attachment_message_to_slack(
+              level: 'INFO',
+              text: message_builder.skipping_text,
+              body: @instance.logs.last(2).first.message,
+            )
+          end
         end
 
         def notify_cancellation

--- a/lib/autoload/kuroko2/workflow/notifier/slack.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/slack.rb
@@ -29,11 +29,11 @@ module Kuroko2
           end
         end
 
-        def notify_retring
+        def notify_retrying
           if @definition.hipchat_notify_finished?
             send_attachment_message_to_slack(
               level: 'INFO',
-              text: message_builder.retring_text,
+              text: message_builder.retrying_text,
               body: @instance.logs.last(2).first.message,
             )
           end

--- a/lib/autoload/kuroko2/workflow/notifier/slack.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/slack.rb
@@ -50,7 +50,7 @@ module Kuroko2
         end
 
         def notify_cancellation
-          if @definition.notify_cancellation
+          if @definition.notify_cancellation || @definition.hipchat_notify_finished?
             send_attachment_message_to_slack(
               level: 'WARNING',
               text: message_builder.failure_text,

--- a/lib/autoload/kuroko2/workflow/notifier/slack.rb
+++ b/lib/autoload/kuroko2/workflow/notifier/slack.rb
@@ -24,7 +24,7 @@ module Kuroko2
             send_attachment_message_to_slack(
               level: 'INFO',
               text: message_builder.launched_text,
-              body: @instance.logs.last(2).first.message,
+              body: @instance.logs.select{ |log| log.level == 'INFO' }.last.try!(:message),
             )
           end
         end
@@ -54,7 +54,7 @@ module Kuroko2
             send_attachment_message_to_slack(
               level: 'WARNING',
               text: message_builder.failure_text,
-              body: @instance.logs.last(2).first.message,
+              body: @instance.logs.select{ |log| log.level == 'WARN' }.last.try!(:message),
             )
           end
         end

--- a/spec/models/job_instance_spec.rb
+++ b/spec/models/job_instance_spec.rb
@@ -38,7 +38,7 @@ describe Kuroko2::JobInstance do
     let(:definition) { create(:job_definition) }
     let(:instance) { definition.job_instances.create! }
 
-    subject! { instance.cancel }
+    subject! { instance.cancel(by: 'test') }
 
     it do
       expect(instance).to be_canceled_at

--- a/spec/workflow/notifier/hipchat_spec.rb
+++ b/spec/workflow/notifier/hipchat_spec.rb
@@ -103,6 +103,66 @@ module Kuroko2::Workflow
       end
     end
 
+    describe '#notify_retring' do
+      context 'with notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = true
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(hipchat_room_object).to receive(:send) do |_, message, option|
+            expect(message).to include('SUCCESS')
+            expect(option[:color]).to eq('yellow')
+          end
+
+          notifier.notify_retring
+        end
+      end
+
+      context 'without notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = false
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(hipchat_room_object).not_to receive(:send)
+          notifier.notify_retring
+        end
+      end
+    end
+
+    describe '#notify_skipping' do
+      context 'with notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = true
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(hipchat_room_object).to receive(:send) do |_, message, option|
+            expect(message).to include('SUCCESS')
+            expect(option[:color]).to eq('yellow')
+          end
+
+          notifier.notify_skipping
+        end
+      end
+
+      context 'without notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = false
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(hipchat_room_object).not_to receive(:send)
+          notifier.notify_skipping
+        end
+      end
+    end
+
     describe '#notify_long_elapsed_time' do
       it 'sends warning mesasge' do
         expect(hipchat_room_object).to receive(:send) do |_, message, option|

--- a/spec/workflow/notifier/hipchat_spec.rb
+++ b/spec/workflow/notifier/hipchat_spec.rb
@@ -103,20 +103,20 @@ module Kuroko2::Workflow
       end
     end
 
-    describe '#notify_retring' do
+    describe '#notify_retrying' do
       context 'with notify_finished' do
         before do
           instance.job_definition.hipchat_notify_finished = true
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends retrying mesasge' do
           expect(hipchat_room_object).to receive(:send) do |_, message, option|
             expect(message).to include('SUCCESS')
             expect(option[:color]).to eq('yellow')
           end
 
-          notifier.notify_retring
+          notifier.notify_retrying
         end
       end
 
@@ -126,9 +126,9 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends retrying mesasge' do
           expect(hipchat_room_object).not_to receive(:send)
-          notifier.notify_retring
+          notifier.notify_retrying
         end
       end
     end
@@ -140,7 +140,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends skipping mesasge' do
           expect(hipchat_room_object).to receive(:send) do |_, message, option|
             expect(message).to include('SUCCESS')
             expect(option[:color]).to eq('yellow')
@@ -156,7 +156,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends skipping mesasge' do
           expect(hipchat_room_object).not_to receive(:send)
           notifier.notify_skipping
         end
@@ -170,7 +170,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends launch mesasge' do
           expect(hipchat_room_object).to receive(:send) do |_, message, option|
             expect(message).to include('SUCCESS')
             expect(option[:color]).to eq('yellow')
@@ -186,7 +186,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends launch mesasge' do
           expect(hipchat_room_object).not_to receive(:send)
           notifier.notify_launch
         end

--- a/spec/workflow/notifier/hipchat_spec.rb
+++ b/spec/workflow/notifier/hipchat_spec.rb
@@ -163,6 +163,36 @@ module Kuroko2::Workflow
       end
     end
 
+    describe '#notify_launch' do
+      context 'with notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = true
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(hipchat_room_object).to receive(:send) do |_, message, option|
+            expect(message).to include('SUCCESS')
+            expect(option[:color]).to eq('yellow')
+          end
+
+          notifier.notify_launch
+        end
+      end
+
+      context 'without notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = false
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(hipchat_room_object).not_to receive(:send)
+          notifier.notify_launch
+        end
+      end
+    end
+
     describe '#notify_long_elapsed_time' do
       it 'sends warning mesasge' do
         expect(hipchat_room_object).to receive(:send) do |_, message, option|

--- a/spec/workflow/notifier/hipchat_spec.rb
+++ b/spec/workflow/notifier/hipchat_spec.rb
@@ -50,6 +50,7 @@ module Kuroko2::Workflow
 
     describe '#notify_cancellation' do
       before do
+        instance.logs.warn('warn')
         instance.job_definition.notify_cancellation = true
         instance.save!
       end

--- a/spec/workflow/notifier/mail_spec.rb
+++ b/spec/workflow/notifier/mail_spec.rb
@@ -75,9 +75,9 @@ module Kuroko2::Workflow
       end
     end
 
-    describe '#notify_retring' do
+    describe '#notify_retrying' do
       it 'does not send mail' do
-        expect { notifier.notify_retring }.not_to change {
+        expect { notifier.notify_retrying }.not_to change {
           ActionMailer::Base.deliveries.size
         }
       end
@@ -85,7 +85,7 @@ module Kuroko2::Workflow
 
     describe '#notify_skipping' do
       it 'does not send mail' do
-        expect { notifier.notify_retring }.not_to change {
+        expect { notifier.notify_skipping }.not_to change {
           ActionMailer::Base.deliveries.size
         }
       end

--- a/spec/workflow/notifier/mail_spec.rb
+++ b/spec/workflow/notifier/mail_spec.rb
@@ -90,5 +90,13 @@ module Kuroko2::Workflow
         }
       end
     end
+
+    describe '#notify_launch' do
+      it 'does not send mail' do
+        expect { notifier.notify_launch }.not_to change {
+          ActionMailer::Base.deliveries.size
+        }
+      end
+    end
   end
 end

--- a/spec/workflow/notifier/mail_spec.rb
+++ b/spec/workflow/notifier/mail_spec.rb
@@ -75,9 +75,17 @@ module Kuroko2::Workflow
       end
     end
 
-    describe '#notify_working' do
+    describe '#notify_retring' do
       it 'does not send mail' do
-        expect { notifier.notify_working }.not_to change {
+        expect { notifier.notify_retring }.not_to change {
+          ActionMailer::Base.deliveries.size
+        }
+      end
+    end
+
+    describe '#notify_skipping' do
+      it 'does not send mail' do
+        expect { notifier.notify_retring }.not_to change {
           ActionMailer::Base.deliveries.size
         }
       end

--- a/spec/workflow/notifier/slack_spec.rb
+++ b/spec/workflow/notifier/slack_spec.rb
@@ -45,6 +45,7 @@ module Kuroko2::Workflow
 
     describe '#notify_cancellation' do
       before do
+        instance.logs.warn('warn')
         instance.job_definition.notify_cancellation = true
         instance.save!
       end

--- a/spec/workflow/notifier/slack_spec.rb
+++ b/spec/workflow/notifier/slack_spec.rb
@@ -89,18 +89,18 @@ module Kuroko2::Workflow
       end
     end
 
-    describe '#notify_retring' do
+    describe '#notify_retrying' do
       context 'with notify_finished' do
         before do
           instance.job_definition.hipchat_notify_finished = true
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends retrying mesasge' do
           expect(notifier).to receive(:send_to_slack).
             with(hash_including(channel: slack_channel)).and_call_original
 
-          notifier.notify_retring
+          notifier.notify_retrying
         end
       end
 
@@ -110,9 +110,9 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends retrying mesasge' do
           expect(notifier).not_to receive(:send_to_slack)
-          notifier.notify_retring
+          notifier.notify_retrying
         end
       end
     end
@@ -124,7 +124,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends skipping mesasge' do
           expect(notifier).to receive(:send_to_slack).
             with(hash_including(channel: slack_channel)).and_call_original
 
@@ -138,7 +138,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends skipping mesasge' do
           expect(notifier).not_to receive(:send_to_slack)
           notifier.notify_skipping
         end
@@ -152,7 +152,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends launch mesasge' do
           expect(notifier).to receive(:send_to_slack).
             with(hash_including(channel: slack_channel)).and_call_original
 
@@ -166,7 +166,7 @@ module Kuroko2::Workflow
           instance.save!
         end
 
-        it 'sends retring mesasge' do
+        it 'sends launch mesasge' do
           expect(notifier).not_to receive(:send_to_slack)
           notifier.notify_launch
         end

--- a/spec/workflow/notifier/slack_spec.rb
+++ b/spec/workflow/notifier/slack_spec.rb
@@ -145,6 +145,34 @@ module Kuroko2::Workflow
       end
     end
 
+    describe '#notify_launch' do
+      context 'with notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = true
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(notifier).to receive(:send_to_slack).
+            with(hash_including(channel: slack_channel)).and_call_original
+
+          notifier.notify_launch
+        end
+      end
+
+      context 'without notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = false
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(notifier).not_to receive(:send_to_slack)
+          notifier.notify_launch
+        end
+      end
+    end
+
     describe '#notify_long_elapsed_time' do
       it 'sends warning mesasge' do
         expect(notifier).to receive(:send_to_slack).

--- a/spec/workflow/notifier/slack_spec.rb
+++ b/spec/workflow/notifier/slack_spec.rb
@@ -89,6 +89,62 @@ module Kuroko2::Workflow
       end
     end
 
+    describe '#notify_retring' do
+      context 'with notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = true
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(notifier).to receive(:send_to_slack).
+            with(hash_including(channel: slack_channel)).and_call_original
+
+          notifier.notify_retring
+        end
+      end
+
+      context 'without notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = false
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(notifier).not_to receive(:send_to_slack)
+          notifier.notify_retring
+        end
+      end
+    end
+
+    describe '#notify_skipping' do
+      context 'with notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = true
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(notifier).to receive(:send_to_slack).
+            with(hash_including(channel: slack_channel)).and_call_original
+
+          notifier.notify_skipping
+        end
+      end
+
+      context 'without notify_finished' do
+        before do
+          instance.job_definition.hipchat_notify_finished = false
+          instance.save!
+        end
+
+        it 'sends retring mesasge' do
+          expect(notifier).not_to receive(:send_to_slack)
+          notifier.notify_skipping
+        end
+      end
+    end
+
     describe '#notify_long_elapsed_time' do
       it 'sends warning mesasge' do
         expect(notifier).to receive(:send_to_slack).


### PR DESCRIPTION
This PR changes the `Notify success event to Slack/Hipchat` option to `Notify all event to Slack/Hipchat`.

And Kuroko2 notifies launch/retrying/skipping/finishing events to Slack/Hipchat, When `Notify all event to Slack/Hipchat` option is checked.

@cookpad/dev-infra 👓 
