### PR TITLE
Fix Kuroko2::JobDefinition.search_by

### DIFF
--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -57,7 +57,7 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
     or_query = column[:name].matches("%#{query}%").or(column[:script].matches("%#{query}%"))
 
     search_by_tag_definition_ids = Kuroko2::JobDefinitionTag.joins(:tag).
-      where('tags.name LIKE ?', "%#{query}%").distinct.pluck(:job_definition_id)
+      where("#{Kuroko2::Tag.table_name}.name LIKE ?", "%#{query}%").distinct.pluck(:job_definition_id)
 
     if search_by_tag_definition_ids.present?
       or_query = or_query.or(column[:id].in(search_by_tag_definition_ids))


### PR DESCRIPTION
`Kuroko2::JobDefinition.search_by` doesn't work correct unless `Kuroko2.config.table_name_prefix` is empty.

```
Started GET "/definitions?utf8=%E2%9C%93&q=ghoege" for ::1 at 2016-11-09 12:04:44 +0900
Processing by Kuroko2::JobDefinitionsController#index as JS
  Parameters: {"utf8"=>"✓", "q"=>"ghoege"}
  Kuroko2::User Load (0.4ms)  SELECT  `kuroko2_users`.* FROM `kuroko2_users` WHERE `kuroko2_users`.`suspended_at` IS NULL AND `kuroko2_users`.`id` = 1 LIMIT 1
Unpermitted parameter: utf8
   (0.4ms)  SELECT DISTINCT `kuroko2_job_definition_tags`.`job_definition_id` FROM `kuroko2_job_definition_tags` INNER JOIN `kuroko2_tags` ON `kuroko2_tags`.`id` = `kuroko2_job_de
 WHERE (tags.name LIKE '%ghoege%')
Completed 500 Internal Server Error in 3ms (ActiveRecord: 0.8ms)


  
ActiveRecord::StatementInvalid (Mysql2::Error: Unknown column 'tags.name' in 'where clause': SELECT DISTINCT `kuroko2_job_definition_tags`.`job_definition_id` FROM `kuroko2_job_de
finition_tags` INNER JOIN `kuroko2_tags` ON `kuroko2_tags`.`id` = `kuroko2_job_definition_tags`.`tag_id` WHERE (tags.name LIKE '%ghoege%')):
```

Job definition search doesn't work.
![image](https://cloud.githubusercontent.com/assets/50920/20126082/b61e2070-a675-11e6-9e86-8ed5c21b9ce4.png)


Please review.