### PR TITLE
Fix sub_process task linker

### DIFF
--- a/app/assets/javascripts/kuroko2/definition_linker.js
+++ b/app/assets/javascripts/kuroko2/definition_linker.js
@@ -1,6 +1,6 @@
 jQuery(function ($) {
   function setDeifinitionLink(script) {
-    script = script.replace(/sub_process:\s+(\d+)\s*\n/, function(match, jobId) {
+    script = script.replace(/sub_process:\s+(\d+)\s*$/gm, function(match, jobId) {
       return '<a href="/definitions/' + jobId + '">' + match + '</a>';
     });
 


### PR DESCRIPTION
- `"sub_process: N"`(without newline at end of script) doesn't match `/sub_process:\s+(\d+)\s*\n/`'
- `"sub_process: N\nsub_process: M\n"`(multiple sub_process tasks) doesn't match `/sub_process:\s+(\d+)\s*$/`

@cookpad/dev-infra please review

## Before
`"sub_process: 2\nsub_process: 3"`

![image](https://cloud.githubusercontent.com/assets/50920/20166118/fb74c4d6-a755-11e6-98ba-b50f2117cd7d.png)

## After
![image](https://cloud.githubusercontent.com/assets/50920/20166109/ec4707a8-a755-11e6-96be-cadba91bc643.png)
