### PR TITLE
Improved table layout

### DIFF
--- a/app/assets/javascripts/kuroko2/narrow_job_definitions.js
+++ b/app/assets/javascripts/kuroko2/narrow_job_definitions.js
@@ -1,9 +1,17 @@
 jQuery(function ($) {
+  var link_to_table_row = function(){
+    $('tr[data-href]').css("cursor", "pointer").click(function(e){
+      document.location = $(this).data('href');
+    });
+  };
+  link_to_table_row();
+
   var bind_data = function(data) {
     $('#tags').html($(data).find('#tags').html());
     $('#definitions').html($(data).find('#definitions').html());
     $('#pagination').html($(data).find('#pagination').html());
     $('html,body').scrollTop(0);
+    link_to_table_row();
     $.bootstrapSortable();
   };
 

--- a/app/assets/stylesheets/kuroko2/application.scss
+++ b/app/assets/stylesheets/kuroko2/application.scss
@@ -13,6 +13,10 @@
   padding-top: 10px;
 }
 
+.spacer-right-3 {
+  margin-right: 3px;
+}
+
 .nowrap {
   white-space: nowrap;
 }

--- a/app/assets/stylesheets/kuroko2/job_definitions.scss
+++ b/app/assets/stylesheets/kuroko2/job_definitions.scss
@@ -9,6 +9,11 @@
 }
 
 .star-holder {
+  a {
+    position: relative;
+    z-index: 10000;
+  }
+
   a:link, a:visited, a:hover, a:active {
     color: #444;
   }

--- a/app/views/kuroko2/dashboard/index.html.slim
+++ b/app/views/kuroko2/dashboard/index.html.slim
@@ -35,15 +35,13 @@
                 th Status
                 th Job Definition Name
                 th Started at
-                th &nbsp;
               - for instance in @instances
-                tr
+                tr data-href="#{job_definition_job_instance_path(instance.job_definition, instance)}"
                   td= instance.id
                   td= labeled_status(instance)
                   td.no-decorate= link_to instance.job_definition.name, job_definition_job_instance_path(instance.job_definition, instance)
                   td.nowrap= l(instance.created_at, format: :short)
-                  td
-                    = link_to raw('<i class="fa fa-chevron-right"></i>Details'), job_definition_job_instance_path(instance.job_definition, instance), class: 'btn btn-default btn-xs'
+
       - else
         .box-body
           .text-muted.well.well-sm.no-shadow There are no working jobs.

--- a/app/views/kuroko2/job_definitions/_list.html.slim
+++ b/app/views/kuroko2/job_definitions/_list.html.slim
@@ -3,24 +3,26 @@
     thead
       tr
         th #
-        th.col-md-3 Name
-        th.col-md-3 Next Job
+        th.col-md-4 Name
+        th.col-md-2 Next Job
         th.col-md-2 Latest Status
-        th.col-md-8 data-defaultsort='disabled' Description
-        th.col-md-1 data-defaultsort='disabled' &nbsp;
+        th.col-md-4 data-defaultsort='disabled' Tags / Description
     tbody
       - for definition in definitions
-        tr
+        tr data-href="#{job_definition_path(definition)}"
           td= definition.id
-          td.no-decorate= link_to definition.name, definition
+          td.no-decorate
+            = link_to definition.name, definition
           - if !definition.suspended? && definition.job_schedules.present?
             - next_job_schedule = definition.job_schedules.map(&:next).min
             td data-value=next_job_schedule.to_i = l(next_job_schedule, format: :short)
           - else
             td data-value="9999999999" --
           td= labeled_status(definition.job_instances.take)
-          td= first_line(definition.description)
           td
-            = link_to raw('<i class="fa fa-chevron-right"></i> View Details'), definition, class: 'btn btn-sm btn-default'
+            - definition.tags.each do |tag|
+              span.text-default.spacer-right-3
+                | [#{tag.name}]
+            = first_line(definition.description)
 - else
   .text-muted.well.well-sm.no-shadow There are no favorite job definitions.

--- a/app/views/kuroko2/job_definitions/_search_results.html.slim
+++ b/app/views/kuroko2/job_definitions/_search_results.html.slim
@@ -24,24 +24,26 @@
         tr
           th &nbsp;
           th #
-          th.col-md-3 Name
-          th.col-md-3 Administrators
-          th.col-md-5 Description
-          th.col-md-1 &nbsp;
+          th.col-md-4 Name
+          th.col-md-2 Administrators
+          th.col-md-6 Tags / Description
         - for definition in definitions
-          tr
+          tr data-href="#{job_definition_path(definition)}"
             td
               span.star-holder
                 = star_link_for(definition)
             td= definition.id
-            td.no-decorate= link_to definition.name, definition
+            td.no-decorate
+              = link_to definition.name, definition
             td.no-decorate
               - definition.admins.each do |user|
                 = link_to user.name, user_path(user)
                 br
-            td= first_line(definition.description)
             td
-              = link_to raw('<i class="fa fa-chevron-right"></i> View Details'), definition, class: 'btn btn-sm btn-default'
+              - definition.tags.each do |tag|
+                span.text-default.spacer-right-3
+                  | [#{tag.name}]
+              = first_line(definition.description)
   - else
     - if params[:q].present?
       .text-muted.well.well-sm.no-shadow No results found for the query.


### PR DESCRIPTION
* Show tags before description.
* Remove "Details" buttons and clickable table row.


## Dashboard

| before   | after  |
| :-------------:| :-----:|
| ![before_dashboard](https://cloud.githubusercontent.com/assets/39011/20300734/ca9b6272-ab63-11e6-8d8e-73b181124c63.png) | ![after_dashboard](https://cloud.githubusercontent.com/assets/39011/20300735/ca9c1aa0-ab63-11e6-97c5-77b42e0cfefd.png) |

## All Job Definitions

| before   | after  |
| :-------------:| :-----:|
| ![before_all_job](https://cloud.githubusercontent.com/assets/39011/20300736/ca9c516e-ab63-11e6-8bdd-a174b6f293c2.png) | ![after_all_job](https://cloud.githubusercontent.com/assets/39011/20300733/ca980eec-ab63-11e6-9cf5-396becccb12a.png) |

cc: @cookpad/dev-infra 
