### PR TITLE
Add confirmation dialog when to cancel failed job instance

### DIFF
--- a/app/views/kuroko2/job_instances/_instance.html.slim
+++ b/app/views/kuroko2/job_instances/_instance.html.slim
@@ -37,6 +37,6 @@
   .box-footer
     .row
       #cancel-button.col-md-4.col-md-offset-8
-        = link_to 'Cancel', job_definition_job_instance_path(@definition, @instance), class: 'btn btn-default btn-block', role: 'button', method: :delete, disabled: !@instance.cancelable?
+        = link_to 'Cancel', job_definition_job_instance_path(@definition, @instance), class: 'btn btn-default btn-block', role: 'button', method: :delete, disabled: !@instance.cancelable?, data: { confirm: 'Are you sure?' }
       #force-cancel-button.col-md-4.col-md-offset-8.display-none
         = link_to 'Force Cancel', force_destroy_job_definition_job_instance_path(@definition, @instance), class: 'btn btn-danger btn-block', role: 'button', method: :delete, disabled: !@instance.working?


### PR DESCRIPTION
Show confirmation dialog when to cancel failed job instance, like that:

![screen shot 2016-12-09 at 11 50 02 am](https://cloud.githubusercontent.com/assets/354940/21035925/ca0bce64-be05-11e6-8b28-15d1ee6ba012.png)
