### PR TITLE
Add foreman to development dependency gem list

### DIFF
--- a/app_template.rb
+++ b/app_template.rb
@@ -8,6 +8,10 @@ gsub_file 'config/database.yml', "encoding: utf8", "encoding: utf8mb4"
 
 gem 'kuroko2'
 
+gem_group :development do
+  gem 'foreman'
+end
+
 route 'mount Kuroko2::Engine => "/"'
 
 create_file "config/kuroko2.yml", <<-EOF


### PR DESCRIPTION
As in [quick start](https://github.com/cookpad/kuroko2/blob/master/docs/index.md#quick-start), I need to install foreman additionally.
So I think foreman gem is put in dependencies of development gemspec.

What do you think?