### PR TITLE
Make use content_for method

### DIFF
--- a/app/views/kuroko2/dashboard/index.html.slim
+++ b/app/views/kuroko2/dashboard/index.html.slim
@@ -1,5 +1,6 @@
-- @title = 'Dashboard'
-- @content_title = '<i class="fa fa-dashboard"></i> Dashboard'
+- content_for :title, 'Dashboard'
+- content_for :content_title do
+  <i class="fa fa-dashboard"></i> Dashboard
 
 .row
   .col-md-7

--- a/app/views/kuroko2/executions/index.html.slim
+++ b/app/views/kuroko2/executions/index.html.slim
@@ -1,5 +1,6 @@
-- @title = 'Executions'
-- @content_title = '<i class="fa fa-tasks"></i> Executions'
+- content_for :title, 'Executions'
+- content_for :content_title do
+  <i class="fa fa-tasks"></i> Executions
 
 .box
   .box-header

--- a/app/views/kuroko2/job_definition_stats/index.html.slim
+++ b/app/views/kuroko2/job_definition_stats/index.html.slim
@@ -1,5 +1,6 @@
-- @title = 'Job Definition Stats'
-- @content_title = '<i class="fa fa-bar-chart"></i> Job Definition Stats'
+- content_for :title, 'Job Definition Stats'
+- content_for :content_title do
+  <i class="fa fa-bar-chart"></i> Job Definition Stats
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/job_definitions/edit.html.slim
+++ b/app/views/kuroko2/job_definitions/edit.html.slim
@@ -1,5 +1,5 @@
-- @title = "##{@definition.id} #{@definition.name} « Job Definitions"
-- @content_title = "##{@definition.id} #{@definition.name}"
+- content_for :title, "##{@definition.id} #{@definition.name} « Job Definitions"
+- content_for :content_title, "##{@definition.id} #{@definition.name}"
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/job_definitions/index.html.slim
+++ b/app/views/kuroko2/job_definitions/index.html.slim
@@ -1,5 +1,6 @@
-- @title = 'Job Definitions'
-- @content_title = '<i class="fa fa-database"></i> Job Definitions'
+- content_for :title, 'Job Definitions'
+- content_for :content_title do
+  <i class="fa fa-database"></i> Job Definitions
 
 .row
   .col-md-9

--- a/app/views/kuroko2/job_definitions/new.html.slim
+++ b/app/views/kuroko2/job_definitions/new.html.slim
@@ -1,5 +1,6 @@
-- @title = 'New Job Definition'
-- @content_title = '<i class="fa fa-database"></i> New Job Definition'
+- content_for :title, 'New Job Definition'
+- content_for :content_title do
+  <i class="fa fa-database"></i> New Job Definition
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/job_definitions/show.html.slim
+++ b/app/views/kuroko2/job_definitions/show.html.slim
@@ -1,5 +1,5 @@
-- @title = "##{@definition.id} #{@definition.name} « Job Definitions"
-- @content_title = "Job Definition Details"
+- content_for :title, "##{@definition.id} #{@definition.name} « Job Definitions"
+- content_for :content_title, "Job Definition Details"
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/job_instances/show.html.slim
+++ b/app/views/kuroko2/job_instances/show.html.slim
@@ -1,5 +1,5 @@
-- @title = "##{@definition.id} #{@definition.name} « Jobs"
-- @content_title = "Job Instance Details"
+- content_for :title, "##{@definition.id} #{@definition.name} « Jobs"
+- content_for :content_title, "Job Instance Details"
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/job_instances/working.html.slim
+++ b/app/views/kuroko2/job_instances/working.html.slim
@@ -1,5 +1,6 @@
-- @title = "Working Jobs"
-- @content_title = '<i class="fa fa-spinner"></i> Working Jobs'
+- content_for :title, "Working Jobs"
+- content_for :content_title do
+  <i class="fa fa-spinner"></i> Working Jobs
 
 .box
   .box-header

--- a/app/views/kuroko2/job_timelines/index.html.slim
+++ b/app/views/kuroko2/job_timelines/index.html.slim
@@ -1,6 +1,9 @@
-- @title = "Job Timelines"
-- @content_title = "<i class=\"fa fa-clock-o\"></i> #{@user.name}'s Job Timelines"
-- @content_title << " tagged by #{params[:tag].join(',')}" if params[:tag].present?
+- content_for :title, "Job Timelines"
+- content_for :content_title do
+  - if params[:tag].present?
+    <i class="fa fa-clock-o"></i> #{@user.name}'s Job Timelines tagged by #{params[:tag].join(', ')}
+  - else
+    <i class="fa fa-clock-o"></i> #{@user.name}'s Job Timelines
 
 .row
   .col-md-12

--- a/app/views/kuroko2/layouts/application.html.slim
+++ b/app/views/kuroko2/layouts/application.html.slim
@@ -1,11 +1,11 @@
 doctype html
 html
   head
-    title #{@title} « Kuroko 2
+    title #{yield(:title)} « Kuroko 2
     meta charset='UTF-8'
     meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'
     link rel='icon' href='/favicon.ico'
-    link type='application/opensearchdescription+xml' rel='search' href='#{osd_path(format: 'xml')}' title='Kuroko2' 
+    link type='application/opensearchdescription+xml' rel='search' href='#{osd_path(format: 'xml')}' title='Kuroko2'
     = csrf_meta_tag
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application'
@@ -59,7 +59,7 @@ html
 
       aside.right-side
         section.content-header
-          h1= raw(@content_title || @title)
+          h1= yield(:content_title).presence || yield(:title)
           = yield :breadcrumb
         section.content
           .container-fluid

--- a/app/views/kuroko2/sessions/invalid_hd.html.slim
+++ b/app/views/kuroko2/sessions/invalid_hd.html.slim
@@ -1,9 +1,9 @@
-- @title = 'Sign in failure'
+- content_for :title, 'Sign in failure'
 
 doctype html
 html.bg-black
   head
-    title #{@title} « Kuroko 2
+    title #{yield(:title)} « Kuroko 2
     meta charset='UTF-8'
     meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'
     = stylesheet_link_tag 'kuroko2/application'

--- a/app/views/kuroko2/sessions/new.html.slim
+++ b/app/views/kuroko2/sessions/new.html.slim
@@ -1,9 +1,9 @@
-- @title = 'Sign in'
+- content_for :title, 'Sign in'
 
 doctype html
 html.bg-black
   head
-    title #{@title} « Kuroko 2
+    title #{yield(:title)} « Kuroko 2
     meta charset='UTF-8'
     meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'
     = stylesheet_link_tag 'kuroko2/application'

--- a/app/views/kuroko2/users/edit.html.slim
+++ b/app/views/kuroko2/users/edit.html.slim
@@ -1,5 +1,5 @@
-- @title = "#{@user.name_was} « Users"
-- @content_title = "Edit User"
+- content_for :title, "#{@user.name_was} « Users"
+- content_for :content_title, 'Edit User'
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/users/index.html.slim
+++ b/app/views/kuroko2/users/index.html.slim
@@ -1,5 +1,6 @@
-- @title = 'Users' + (params[:target] == 'group' ? ' > Groups' : '')
-- @content_title = "<i class=\"fa fa-users\"></i> Users#{params[:target] == 'group' ? ' <i class="fa fa-angle-double-right"></i> Groups' : ''}"
+- content_for :title, 'Users' + (params[:target] == 'group' ? ' > Groups' : '')
+- content_for :content_title do
+  <i class="fa fa-users"></i> Users#{params[:target] == 'group' ? ' <i class="fa fa-angle-double-right"></i> Groups' : ''}
 - @scope = @users
 
 - if @user.errors.any?

--- a/app/views/kuroko2/users/show.html.slim
+++ b/app/views/kuroko2/users/show.html.slim
@@ -1,5 +1,6 @@
-- @title = "#{@user.name} « Users"
-- @content_title = "<i class='fa fa-user'></i> User Details"
+- content_for :title, "#{@user.name} « Users"
+- content_for :content_title do
+  <i class="fa fa-user"></i> User Details
 
 - content_for :breadcrumb do
   ol.breadcrumb

--- a/app/views/kuroko2/workers/index.html.slim
+++ b/app/views/kuroko2/workers/index.html.slim
@@ -1,5 +1,6 @@
-- @title = 'Kuroko Workers'
-- @content_title = '<i class="fa fa-rocket"></i> Kuroko Workers'
+- content_for :title, 'Kuroko Workers'
+- content_for :content_title do
+  <i class="fa fa-rocket"></i> Kuroko Workers
 
 .box#workers
   .box-header

--- a/app/views/layouts/kuroko2/application.html.slim
+++ b/app/views/layouts/kuroko2/application.html.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title #{@title} « Kuroko 2
+    title #{yield(:title)} « Kuroko 2
     meta charset='UTF-8'
     meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'
     link rel='icon' href='/favicon.ico'
@@ -63,7 +63,7 @@ html
 
       aside.right-side
         section.content-header
-          h1= raw(@content_title || @title)
+          h1= yield(:content_title).presence || yield(:title)
           = yield :breadcrumb
         section.content
           .container-fluid

--- a/spec/features/dashborad_spec.rb
+++ b/spec/features/dashborad_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe "User shows dashboard", type: :feature do
       expect(page).to have_selector('#definitions_list table tbody tr', count: 1)
 
       expect(page).to have_content('There are no working jobs.')
+      expect(page).to have_title('Dashboard « Kuroko 2')
+      expect(page).to have_selector('i.fa.fa-dashboard', text: '')
+      expect(page).to have_selector('h1', text: /Dashboard/)
     end
 
     context 'if the favorite job is working' do

--- a/spec/features/workers_spec.rb
+++ b/spec/features/workers_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe "Show list of workers", type: :feature do
     visit kuroko2.workers_path
     expect(page).to have_selector('#workers table tbody tr', count: 2)
     expect(page).not_to have_content('echo Hello!')
+    expect(page).to have_title('Kuroko Workers « Kuroko 2')
+    expect(page).to have_selector('i.fa.fa-rocket', text: '')
+    have_selector('h1', text: /Kuroko Workers/)
 
     worker.update_column(:execution_id, token.execution.id)
 


### PR DESCRIPTION
I'd prefer to use `content_for` tag when I want to set title tag from view partials.

This pull-request fixes to set title by using `content_for` and `yield` clause which are view helper methods.

![20161230172101_img20161230-9-14xxy7t](https://cloud.githubusercontent.com/assets/6443461/21569398/da9ab3de-ceff-11e6-86c5-611f750220c6.png)