### PR TITLE
Render instance logs by JavaScript to fix flicker

### DIFF
--- a/app/assets/javascripts/kuroko2/job_instances.js
+++ b/app/assets/javascripts/kuroko2/job_instances.js
@@ -28,12 +28,27 @@ jQuery(function ($) {
     var logsPath = $('#logs').data("logs-path");
 
     $.get(logsPath, function (data) {
-      $('#logs').html($(data).find('#logs').html());
+      var tbody = $('#logs tbody');
+      var lastLogId = +tbody.data('last-log-id');
+      data.logs.forEach(function(log) {
+        if (log.id > lastLogId) {
+          var tr = $('<tr>');
+          var label = $('<span class="label">').text(log.level).addClass(log.class_for_label);
+          tr.append($('<td>').append(label));
+          tr.append($('<td class="nowrap">').text(log.created_at));
+          tr.append($('<td class="log">').html(log.message_html));
+          tbody.append(tr);
+        }
+      });
+      if (data.logs.length !== 0) {
+        tbody.data('last-log-id', data.logs[data.logs.length - 1].id);
+      }
 
-      if (!$('#logs table').data("reload")) {
+      if (!data.reload) {
         clearInterval(logIntervalId);
         updateInstance();
       }
+      tbody.find('.loading').empty();
     });
   };
 
@@ -82,9 +97,7 @@ jQuery(function ($) {
     updateLogs();
   };
 
-  if ($('#logs table').data("reload")) {
-    logIntervalId = setInterval(updateAll, 2000);
-  }
+  logIntervalId = setInterval(updateAll, 2000);
 
   if ($('#execution_logs').size() > 0) {
     startGetExecutionLog();

--- a/app/controllers/kuroko2/logs_controller.rb
+++ b/app/controllers/kuroko2/logs_controller.rb
@@ -1,15 +1,40 @@
 class Kuroko2::LogsController < Kuroko2::ApplicationController
   def index
-    @definition = Kuroko2::JobDefinition.find(logs_params[:job_definition_id])
-    @instance   = Kuroko2::JobInstance.find(logs_params[:job_instance_id])
-    @logs       = @instance.logs.order(:id)
+    definition = Kuroko2::JobDefinition.find(logs_params[:job_definition_id])
+    instance   = Kuroko2::JobInstance.find(logs_params[:job_instance_id])
+    logs       = instance.logs.order(:id)
 
-    render layout: false
+    render json: {
+      reload: instance.working? && !instance.error?,
+      logs: logs.map { |log|
+        {
+          id: log.id,
+          level: log.level,
+          class_for_label: class_for_label(log.level),
+          created_at: log.created_at,
+          message_html: Rinku.auto_link(ERB::Util.h(log.message), :urls),
+        }
+      },
+    }
   end
 
   private
 
   def logs_params
     params.permit(:job_definition_id, :job_instance_id)
+  end
+
+  def class_for_label(level)
+    modifier = case level
+               when 'INFO'
+                 'info'
+               when 'ERROR'
+                 'danger'
+               when 'WARN'
+                 'warning'
+               else
+                 'default'
+               end
+    "label-#{modifier}"
   end
 end

--- a/app/helpers/kuroko2/job_instances_helper.rb
+++ b/app/helpers/kuroko2/job_instances_helper.rb
@@ -1,19 +1,5 @@
 module Kuroko2
   module JobInstancesHelper
-    def labeled_log_level(level)
-      modifier = case level
-                 when 'INFO'
-                   'info'
-                 when 'ERROR'
-                   'danger'
-                 when 'WARN'
-                   'warning'
-                 else
-                   'default'
-                 end
-      content_tag(:span, level, class: "label label-#{modifier}")
-    end
-
     def labeled_token_status(status)
       modifier = case status
                  when 'working'

--- a/app/views/kuroko2/job_instances/_logs.html.slim
+++ b/app/views/kuroko2/job_instances/_logs.html.slim
@@ -9,17 +9,17 @@ ul class="nav nav-pills" role="tablist"
   .box-header
   .box-body.tab-content
     div class="tab-pane active" role="tabpanel" id="logs" data-logs-path="#{job_definition_job_instance_logs_path(@definition, @instance)}"
-      table.table.table-condensed.table-hover data-reload="#{@instance.working? && !@instance.error?}"
+      table.table.table-condensed.table-hover
         thead
           tr
             th &nbsp;
             th.col-md-1 Time
             th.col-md-10 Message
-          - for log in @logs
-            tr
-              td= labeled_log_level(log.level)
-              td.nowrap= log.created_at
-              td.log= rinku_auto_link(log.message, :urls)
+        tbody data-last-log-id="0"
+          tr.loading
+            td
+              i.fa.fa-spinner.fa-spin
+                span.sr-only Loading logs...
       = javascript_include_tag 'kuroko2/instance_linker'
 
     div class="tab-pane" role="tabpanel" id="execution_logs" data-api-path="#{job_definition_job_instance_execution_logs_path(@definition, @instance)}" data-logger="#{Kuroko2.config.execution_logger.try!(:type)}"

--- a/app/views/kuroko2/job_instances/show.html.slim
+++ b/app/views/kuroko2/job_instances/show.html.slim
@@ -16,4 +16,4 @@
 
 .row
   .col-md-12#logs-holder
-    = render template: 'kuroko2/logs/index'
+    = render 'logs'


### PR DESCRIPTION
Since instance logs are updated every 2 seconds, it's hard to select and
copy logs. I'd like to append instance logs instead of replacing them.

## Before
https://gyazo.wanko.cc/fab573dc6a446fb258c3631201691dbd.webm

## After
https://gyazo.wanko.cc/77b71bc757d29900c032e278b09e2d6b.webm