### PR TITLE
ignore generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/dummy/db/*.sqlite3-journal
 spec/dummy/log/*.log
 spec/dummy/tmp/
 Gemfile.lock
+doc/


### PR DESCRIPTION
ignore `docs/` and `.yardoc/` which are generated on development processes.