### PR TITLE
Fix job not being recorded as completed when exit status > 127

### DIFF
--- a/db/migrate/028_change_exit_status_to_unsigned_tinyint.rb
+++ b/db/migrate/028_change_exit_status_to_unsigned_tinyint.rb
@@ -1,0 +1,9 @@
+class ChangeExitStatusToUnsignedTinyint < ActiveRecord::Migration
+  def up
+    change_column :executions, :exit_status, 'tinyint(4) unsigned'
+  end
+
+  def down
+    change_column :executions, :exit_status, :integer, limit: 1
+  end
+end

--- a/db/migrate/028_change_exit_status_to_unsigned_tinyint.rb
+++ b/db/migrate/028_change_exit_status_to_unsigned_tinyint.rb
@@ -1,6 +1,6 @@
 class ChangeExitStatusToUnsignedTinyint < ActiveRecord::Migration
   def up
-    change_column :executions, :exit_status, 'tinyint(4) unsigned'
+    change_column :executions, :exit_status, :integer, limit: 2
   end
 
   def down

--- a/db/migrate/028_change_exit_status_to_unsigned_tinyint.rb
+++ b/db/migrate/028_change_exit_status_to_unsigned_tinyint.rb
@@ -1,4 +1,4 @@
-class ChangeExitStatusToUnsignedTinyint < ActiveRecord::Migration
+class ChangeExitStatusToUnsignedTinyint < ActiveRecord::Migration[5.0]
   def up
     change_column :executions, :exit_status, :integer, limit: 2
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 27) do
+ActiveRecord::Schema.define(version: 28) do
 
   create_table "admin_assignments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer  "user_id",           null: false
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 27) do
     t.text     "context",                limit: 65535,                           null: false
     t.integer  "pid"
     t.text     "output",                 limit: 4294967295
-    t.integer  "exit_status",            limit: 1
+    t.integer  "exit_status",            limit: 1,                                            unsigned: true
     t.integer  "term_signal",            limit: 1
     t.datetime "started_at"
     t.datetime "finished_at"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 28) do
     t.text     "context",                limit: 65535,                           null: false
     t.integer  "pid"
     t.text     "output",                 limit: 4294967295
-    t.integer  "exit_status",            limit: 1,                                            unsigned: true
+    t.integer  "exit_status",            limit: 2
     t.integer  "term_signal",            limit: 1
     t.datetime "started_at"
     t.datetime "finished_at"


### PR DESCRIPTION
Kuroko would fail to record the completion of the job when it exits
with status bigger than 127 as it causes an ActiveModel::RangeError.