### PR TITLE
Fix length validation for slack_channel column to adapt # symbol

### DIFF
--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -67,10 +67,12 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
   validate :script_syntax
   validate :validate_number_of_admins
   validates :hipchat_additional_text, length: { maximum: 180 }
-  validates :slack_channel, length: { maximum: 21 }, format: {
-    with: /\A#[^\.\s]+\z/, allow_blank: true,
-    message: ' must start with # and must not include any dots or spaces'
-  }
+  validates :slack_channel,
+    length: { maximum: 22, too_long: ' is too long (maximum is 21 characters without `#` symbol at the head)' },
+    format: {
+      with: /\A#[^\.\s]+\z/, allow_blank: true,
+      message: ' must start with # and must not include any dots or spaces'
+    }
   validates :webhook_url, format: { with: /\A#{URI::regexp(%w(http https))}\z/, allow_blank: true }
 
   def proceed_multi_instance?


### PR DESCRIPTION
Slack's channel length is up to 21 characters without `#` symbol at the
head. However JobDefinition#slack_channel's maximum length is 21 with
`#`. So I change the length to 22 characters to allow 21-character
channel names.

---

@cookpad/dev-infra 👓 ?