### PR TITLE
Add execution_id to process_signals table and use it

### DIFF
--- a/app/controllers/kuroko2/executions_controller.rb
+++ b/app/controllers/kuroko2/executions_controller.rb
@@ -8,7 +8,7 @@ class Kuroko2::ExecutionsController < Kuroko2::ApplicationController
 
   def destroy
     if @execution.try!(:pid)
-      hostname = Kuroko2::Worker.executing(@execution.id).try!(:hostname)
+      hostname = Kuroko2::Worker.executing(@execution.id).try!(:hostname) || ''
       # XXX: Store pid and hostname for compatibility
       Kuroko2::ProcessSignal.create!(pid: @execution.pid, hostname: hostname, execution_id: @execution.id)
     end

--- a/app/controllers/kuroko2/executions_controller.rb
+++ b/app/controllers/kuroko2/executions_controller.rb
@@ -7,9 +7,10 @@ class Kuroko2::ExecutionsController < Kuroko2::ApplicationController
   end
 
   def destroy
-    if @execution.try(:pid)
-      hostname = Kuroko2::Worker.executing(@execution.id).try(:hostname)
-      Kuroko2::ProcessSignal.create!(pid: @execution.pid, hostname: hostname) if hostname
+    if @execution.try!(:pid)
+      hostname = Kuroko2::Worker.executing(@execution.id).try!(:hostname)
+      # XXX: Store pid and hostname for compatibility
+      Kuroko2::ProcessSignal.create!(pid: @execution.pid, hostname: hostname, execution_id: @execution.id)
     end
 
     redirect_to job_definition_job_instance_path(job_definition_id: execution_params[:job_definition_id], id: execution_params[:job_instance_id])

--- a/app/models/kuroko2/process_signal.rb
+++ b/app/models/kuroko2/process_signal.rb
@@ -1,8 +1,10 @@
 class Kuroko2::ProcessSignal < Kuroko2::ApplicationRecord
   include Kuroko2::TableNameCustomizable
 
+  belongs_to :execution
+
   scope :unstarted, -> { where(started_at: nil) }
-  scope :on, ->(hostname) { where(hostname: hostname) }
+  scope :on, ->(hostname) { joins(execution: :worker).merge(Kuroko2::Worker.on(hostname)) }
 
   def self.poll(hostname)
     self.transaction do

--- a/db/migrate/029_add_execution_id_to_process_signals.rb
+++ b/db/migrate/029_add_execution_id_to_process_signals.rb
@@ -1,0 +1,5 @@
+class AddExecutionIdToProcessSignals < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :process_signals, :execution, foreign_key: false
+  end
+end

--- a/lib/autoload/kuroko2/workflow/task/execute.rb
+++ b/lib/autoload/kuroko2/workflow/task/execute.rb
@@ -75,17 +75,12 @@ module Kuroko2
           timeout = token.context['TIMEOUT'].to_i
 
           if timeout > 0 && ((execution.created_at + timeout.minutes) < Time.current) && execution.pid
-            hostname = Worker.executing(execution.id).try(:hostname)
-            if hostname
-              ProcessSignal.create!(pid: execution.pid, hostname: hostname)
-              message = "(token #{token.uuid}) Timeout occurred after #{timeout} minutes."
-              token.job_instance.logs.info(message)
-              Kuroko2.logger.info(message)
-            else
-              message = "(token #{token.uuid}) The timeout task is not working. Hostname not found on execution_id #{execution.id}"
-              token.job_instance.logs.error(message)
-              Kuroko2.logger.error(message)
-            end
+            hostname = Worker.executing(execution.id).try!(:hostname)
+            # XXX: Store pid and hostname for compatibility
+            ProcessSignal.create!(pid: execution.pid, hostname: hostname, execution_id: execution.id)
+            message = "(token #{token.uuid}) Timeout occurred after #{timeout} minutes."
+            token.job_instance.logs.info(message)
+            Kuroko2.logger.info(message)
           end
         end
       end

--- a/spec/command/kill_spec.rb
+++ b/spec/command/kill_spec.rb
@@ -4,16 +4,22 @@ module Kuroko2::Command
   describe Kill do
 
     describe '#execute' do
-      subject { Kill.new('test', '1').execute }
+      subject { Kill.new(hostname, '1').execute }
 
-      before { Process.detach(pid) }
+      before do
+        execution.pid = Process.spawn('sleep 10')
+        Process.detach(execution.pid)
+        worker.update!(execution_id: execution.id)
+      end
 
-      let!(:signal) { create(:process_signal, pid: pid, hostname: 'test') }
-      let(:pid) { Process.spawn('sleep 10') }
+      let!(:signal) { create(:process_signal, pid: execution.pid, hostname: 'test', execution_id: execution.id) }
+      let(:execution) { create(:execution) }
+      let(:hostname) { 'test' }
+      let(:worker) { create(:worker, hostname: hostname) }
 
       it 'terminates spawned process' do
         is_expected.to eq signal
-        expect { Process.kill(0, pid) }.to raise_error(Errno::ESRCH)
+        expect { Process.kill(0, execution.pid) }.to raise_error(Errno::ESRCH)
       end
     end
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,330 +10,146 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 28) do
+ActiveRecord::Schema.define(version: 29) do
 
   create_table "admin_assignments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
+    t.integer  "user_id",           null: false
+    t.integer  "job_definition_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["user_id", "job_definition_id"], name: "user_id", unique: true
+    t.index ["user_id", "job_definition_id"], name: "user_id", unique: true, using: :btree
   end
 
   create_table "executions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.integer "job_instance_id"
-    t.integer "token_id"
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.text "shell", null: false
-    t.text "context", null: false
-    t.integer "pid"
-    t.text "output", limit: 4294967295
-    t.integer "exit_status", limit: 2
-    t.integer "term_signal", limit: 1
+    t.string   "uuid",                   limit: 36,                              null: false
+    t.integer  "job_definition_id"
+    t.integer  "job_definition_version"
+    t.integer  "job_instance_id"
+    t.integer  "token_id"
+    t.string   "queue",                  limit: 180,        default: "@default", null: false
+    t.text     "shell",                  limit: 65535,                           null: false
+    t.text     "context",                limit: 65535,                           null: false
+    t.integer  "pid"
+    t.text     "output",                 limit: 4294967295
+    t.integer  "exit_status",            limit: 2
+    t.integer  "term_signal",            limit: 1
     t.datetime "started_at"
     t.datetime "finished_at"
     t.datetime "mailed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["job_definition_id", "token_id"], name: "index_kuroko2_executions_on_job_definition_id_and_token_id", unique: true
-    t.index ["started_at"], name: "started_at"
+    t.index ["job_definition_id", "token_id"], name: "job_definition_id", unique: true, using: :btree
+    t.index ["started_at"], name: "started_at", using: :btree
   end
 
   create_table "job_definition_tags", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id", null: false
-    t.integer "tag_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id", "tag_id"], name: "kuroko2_definition_tag_idx", unique: true
-    t.index ["tag_id"], name: "job_definition_tags_tag_id"
+    t.integer  "job_definition_id", null: false
+    t.integer  "tag_id",            null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.index ["job_definition_id", "tag_id"], name: "job_definition_id", unique: true, using: :btree
+    t.index ["tag_id"], name: "job_definition_tags_tag_id", using: :btree
   end
 
   create_table "job_definitions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "version", default: 0, null: false
-    t.string "name", limit: 180, null: false
-    t.text "description", null: false
-    t.text "script", null: false
-    t.boolean "suspended", default: false, null: false
-    t.integer "prevent_multi", default: 1, null: false
-    t.boolean "notify_cancellation", default: true, null: false
-    t.string "hipchat_room", limit: 180, default: "", null: false
-    t.boolean "hipchat_notify_finished", default: true, null: false
-    t.string "hipchat_additional_text", limit: 180
-    t.string "slack_channel", limit: 180, default: "", null: false
-    t.boolean "api_allowed", default: false, null: false
+    t.integer  "version",                               default: 0,     null: false
+    t.string   "name",                    limit: 180,                   null: false
+    t.text     "description",             limit: 65535,                 null: false
+    t.text     "script",                  limit: 65535,                 null: false
+    t.boolean  "suspended",                             default: false, null: false
+    t.integer  "prevent_multi",                         default: 1,     null: false
+    t.boolean  "notify_cancellation",                   default: true,  null: false
+    t.string   "hipchat_room",            limit: 180,   default: "",    null: false
+    t.boolean  "hipchat_notify_finished",               default: true,  null: false
+    t.string   "hipchat_additional_text", limit: 180
+    t.string   "slack_channel",           limit: 180,   default: "",    null: false
+    t.boolean  "api_allowed",                           default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "webhook_url"
-    t.index ["name"], name: "name"
+    t.text     "webhook_url",             limit: 65535
+    t.index ["name"], name: "name", using: :btree
   end
 
   create_table "job_instances", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.text "script"
+    t.integer  "job_definition_id"
+    t.integer  "job_definition_version"
+    t.text     "script",                 limit: 65535
     t.datetime "finished_at"
     t.datetime "canceled_at"
     t.datetime "error_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["finished_at", "canceled_at", "job_definition_id"], name: "job_instance_idx"
-    t.index ["job_definition_id"], name: "index_kuroko2_job_instances_on_job_definition_id"
+    t.index ["finished_at", "canceled_at", "job_definition_id"], name: "finished_at", using: :btree
+    t.index ["job_definition_id"], name: "job_definition_id", using: :btree
   end
 
   create_table "job_schedules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.string "cron", limit: 180
+    t.integer  "job_definition_id"
+    t.string   "cron",              limit: 180
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["job_definition_id", "cron"], name: "kuroko2_schedules_definition_id_cron_idx", unique: true
+    t.index ["job_definition_id", "cron"], name: "job_definition_id", unique: true, using: :btree
   end
 
   create_table "job_suspend_schedules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.string "cron", limit: 180
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id", "cron"], name: "kuroko2_suspend_schedules_definition_id_cron_idx", unique: true
-  end
-
-  create_table "admin_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["user_id", "job_definition_id"], name: "user_id", unique: true
-  end
-
-  create_table "executions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.integer "job_instance_id"
-    t.integer "token_id"
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.text "shell", null: false
-    t.text "context", null: false
-    t.integer "pid"
-    t.text "output", limit: 4294967295
-    t.integer "exit_status", limit: 2
-    t.integer "term_signal", limit: 1
-    t.datetime "started_at"
-    t.datetime "finished_at"
-    t.datetime "mailed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["job_definition_id", "token_id"], name: "index_kuroko2_executions_on_job_definition_id_and_token_id", unique: true
-    t.index ["started_at"], name: "started_at"
-  end
-
-  create_table "job_definition_tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id", null: false
-    t.integer "tag_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id", "tag_id"], name: "kuroko2_definition_tag_idx", unique: true
-    t.index ["tag_id"], name: "job_definition_tags_tag_id"
-  end
-
-  create_table "job_definitions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "version", default: 0, null: false
-    t.string "name", limit: 180, null: false
-    t.text "description", null: false
-    t.text "script", null: false
-    t.boolean "suspended", default: false, null: false
-    t.integer "prevent_multi", default: 1, null: false
-    t.boolean "notify_cancellation", default: true, null: false
-    t.string "hipchat_room", limit: 180, default: "", null: false
-    t.boolean "hipchat_notify_finished", default: true, null: false
-    t.string "hipchat_additional_text", limit: 180
-    t.string "slack_channel", limit: 180, default: "", null: false
-    t.boolean "api_allowed", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text "webhook_url"
-    t.index ["name"], name: "name"
-  end
-
-  create_table "job_instances", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.text "script"
-    t.datetime "finished_at"
-    t.datetime "canceled_at"
-    t.datetime "error_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["finished_at", "canceled_at", "job_definition_id"], name: "job_instance_idx"
-    t.index ["job_definition_id"], name: "index_kuroko2_job_instances_on_job_definition_id"
-  end
-
-  create_table "job_schedules", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.string "cron", limit: 180
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["job_definition_id", "cron"], name: "kuroko2_schedules_definition_id_cron_idx", unique: true
-  end
-
-  create_table "job_suspend_schedules", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.string "cron", limit: 180
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id", "cron"], name: "kuroko2_suspend_schedules_definition_id_cron_idx", unique: true
-  end
-
-  create_table "logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_instance_id"
-    t.string "level", limit: 10
-    t.text "message", limit: 4294967295
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["job_instance_id"], name: "job_instance_id"
-  end
-
-  create_table "memory_consumption_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_instance_id"
-    t.integer "value", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_instance_id"], name: "index_kuroko2_memory_consumption_logs_on_job_instance_id"
-  end
-
-  create_table "memory_expectancies", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "expected_value", default: 0, null: false
-    t.integer "job_definition_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id"], name: "index_kuroko2_memory_expectancies_on_job_definition_id"
-  end
-
-  create_table "process_signals", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180, default: "", null: false
-    t.integer "pid", null: false
-    t.integer "number", limit: 1, default: 15, null: false
-    t.datetime "started_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text "message"
-    t.index ["hostname", "started_at"], name: "hostname_started_at"
-  end
-
-  create_table "stars", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["user_id", "job_definition_id"], name: "index_kuroko2_stars_on_user_id_and_job_definition_id", unique: true
-  end
-
-  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "name", limit: 100, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_kuroko2_tags_on_name", unique: true
-  end
-
-  create_table "ticks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.datetime "at"
-  end
-
-  create_table "tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.integer "job_instance_id"
-    t.integer "parent_id"
-    t.text "script", null: false
-    t.string "path", limit: 180, default: "/", null: false
-    t.integer "status", default: 0, null: false
-    t.text "message", null: false
-    t.text "context", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["parent_id"], name: "parent_id"
-    t.index ["status"], name: "status"
-  end
-
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "provider", limit: 180, default: "google_oauth2", null: false
-    t.string "uid", limit: 180, null: false
-    t.string "name", limit: 180, default: "", null: false
-    t.string "email", limit: 180, null: false
-    t.string "first_name", limit: 180, default: "", null: false
-    t.string "last_name", limit: 180, default: "", null: false
-    t.string "image", limit: 180, default: "", null: false
-    t.datetime "suspended_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["email"], name: "email"
-    t.index ["uid", "suspended_at"], name: "uid_2"
-    t.index ["uid"], name: "uid", unique: true
-  end
-
-  create_table "workers", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180, null: false
-    t.integer "worker_id", limit: 1, null: false
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.boolean "working", default: false, null: false
-    t.integer "execution_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["hostname", "worker_id"], name: "hostname", unique: true
+    t.integer  "job_definition_id"
+    t.string   "cron",              limit: 180
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.index ["job_definition_id", "cron"], name: "job_definition_id", unique: true, using: :btree
   end
 
   create_table "logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_instance_id"
-    t.string "level", limit: 10
-    t.text "message", limit: 4294967295
+    t.integer  "job_instance_id"
+    t.string   "level",           limit: 10
+    t.text     "message",         limit: 4294967295
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["job_instance_id"], name: "job_instance_id"
+    t.index ["job_instance_id"], name: "job_instance_id", using: :btree
   end
 
   create_table "memory_consumption_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_instance_id"
-    t.integer "value", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_instance_id"], name: "index_kuroko2_memory_consumption_logs_on_job_instance_id"
+    t.integer  "job_instance_id"
+    t.integer  "value",           null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["job_instance_id"], name: "index_memory_consumption_logs_on_job_instance_id", using: :btree
   end
 
   create_table "memory_expectancies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "expected_value", default: 0, null: false
-    t.integer "job_definition_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id"], name: "index_kuroko2_memory_expectancies_on_job_definition_id"
+    t.integer  "expected_value",    default: 0, null: false
+    t.integer  "job_definition_id"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.index ["job_definition_id"], name: "index_memory_expectancies_on_job_definition_id", using: :btree
   end
 
   create_table "process_signals", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180, default: "", null: false
-    t.integer "pid", null: false
-    t.integer "number", limit: 1, default: 15, null: false
+    t.string   "hostname",     limit: 180,   default: "", null: false
+    t.integer  "pid",                                     null: false
+    t.integer  "number",       limit: 1,     default: 15, null: false
     t.datetime "started_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "message"
-    t.index ["hostname", "started_at"], name: "hostname_started_at"
+    t.text     "message",      limit: 65535
+    t.integer  "execution_id"
+    t.index ["execution_id"], name: "index_kuroko2_process_signals_on_execution_id", using: :btree
+    t.index ["hostname", "started_at"], name: "hostname_started_at", using: :btree
   end
 
   create_table "stars", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
+    t.integer  "user_id",           null: false
+    t.integer  "job_definition_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["user_id", "job_definition_id"], name: "index_kuroko2_stars_on_user_id_and_job_definition_id", unique: true
+    t.index ["user_id", "job_definition_id"], name: "user_id", unique: true, using: :btree
   end
 
   create_table "tags", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "name", limit: 100, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_kuroko2_tags_on_name", unique: true
+    t.string   "name",       limit: 100, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.index ["name"], name: "name", unique: true, using: :btree
   end
 
   create_table "ticks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
@@ -341,47 +157,47 @@ ActiveRecord::Schema.define(version: 28) do
   end
 
   create_table "tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.integer "job_instance_id"
-    t.integer "parent_id"
-    t.text "script", null: false
-    t.string "path", limit: 180, default: "/", null: false
-    t.integer "status", default: 0, null: false
-    t.text "message", null: false
-    t.text "context", null: false
+    t.string   "uuid",                   limit: 36,                  null: false
+    t.integer  "job_definition_id"
+    t.integer  "job_definition_version"
+    t.integer  "job_instance_id"
+    t.integer  "parent_id"
+    t.text     "script",                 limit: 65535,               null: false
+    t.string   "path",                   limit: 180,   default: "/", null: false
+    t.integer  "status",                               default: 0,   null: false
+    t.text     "message",                limit: 65535,               null: false
+    t.text     "context",                limit: 65535,               null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["parent_id"], name: "parent_id"
-    t.index ["status"], name: "status"
+    t.index ["parent_id"], name: "parent_id", using: :btree
+    t.index ["status"], name: "status", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "provider", limit: 180, default: "google_oauth2", null: false
-    t.string "uid", limit: 180, null: false
-    t.string "name", limit: 180, default: "", null: false
-    t.string "email", limit: 180, null: false
-    t.string "first_name", limit: 180, default: "", null: false
-    t.string "last_name", limit: 180, default: "", null: false
-    t.string "image", limit: 180, default: "", null: false
+    t.string   "provider",     limit: 180, default: "google_oauth2", null: false
+    t.string   "uid",          limit: 180,                           null: false
+    t.string   "name",         limit: 180, default: "",              null: false
+    t.string   "email",        limit: 180,                           null: false
+    t.string   "first_name",   limit: 180, default: "",              null: false
+    t.string   "last_name",    limit: 180, default: "",              null: false
+    t.string   "image",        limit: 180, default: "",              null: false
     t.datetime "suspended_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["email"], name: "email"
-    t.index ["uid", "suspended_at"], name: "uid_2"
-    t.index ["uid"], name: "uid", unique: true
+    t.index ["email"], name: "email", using: :btree
+    t.index ["uid", "suspended_at"], name: "uid_2", using: :btree
+    t.index ["uid"], name: "uid", unique: true, using: :btree
   end
 
   create_table "workers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180, null: false
-    t.integer "worker_id", limit: 1, null: false
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.boolean "working", default: false, null: false
-    t.integer "execution_id"
+    t.string   "hostname",     limit: 180,                      null: false
+    t.integer  "worker_id",    limit: 1,                        null: false
+    t.string   "queue",        limit: 180, default: "@default", null: false
+    t.boolean  "working",                  default: false,      null: false
+    t.integer  "execution_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["hostname", "worker_id"], name: "hostname", unique: true
+    t.index ["hostname", "worker_id"], name: "hostname", unique: true, using: :btree
   end
 
 end


### PR DESCRIPTION
I'm planning to implement a new worker like command-executor.
Since it doesn't run commands in the same host but runs commands in
Amazon ECS, process_signals cannot have meaningful pid and hostname. I
think process_signals actually references executions, so I've added
execution_id column to process_signals table.

@eisuke @takai @cookpad/dev-infra please review