### PR TITLE
Use MutationObserver to observe log for work instance_linker.js correctly

### DIFF
--- a/app/assets/javascripts/kuroko2/instance_linker.js
+++ b/app/assets/javascripts/kuroko2/instance_linker.js
@@ -1,10 +1,22 @@
 jQuery(function ($) {
-  $('td.log').each(function(){
-    var logText = $(this).html();
-    $(this).html(
-      logText.replace(/instance#(\d+)\/(\d+)(?:\s+|\.)/, function(match, jobId, instanceId){
-	return '<a href="/definitions/' + jobId + '/instances/' + instanceId+ '">' + match + '</a>';
-      })
-    );
+  var logParent = document.querySelector('#logs tbody');
+  var observer = new MutationObserver(function(mutations) {
+    if (mutations.some(x =>
+      x.addedNodes
+        && x.addedNodes instanceof NodeList
+        && x.addedNodes.length > 0
+        && x.type == 'childList'
+      )
+    ) {
+      $('td.log').each(function() {
+        var logText = $(this).html();
+        $(this).html(
+          logText.replace(/instance#(\d+)\/(\d+)(?:\s+|\.|$)/, function(match, jobId, instanceId) {
+            return '<a href="/definitions/' + jobId + '/instances/' + instanceId+ '">' + match + '</a>';
+          })
+        );
+      });
+    }
   });
+  observer.observe(logParent, {childList: true, substree: true});
 });

--- a/app/assets/javascripts/kuroko2/instance_linker.js
+++ b/app/assets/javascripts/kuroko2/instance_linker.js
@@ -1,4 +1,8 @@
 jQuery(function ($) {
+  var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
+  if (!MutationObserver) {
+    return;
+  }
   var logParent = document.querySelector('#logs tbody');
   var observer = new MutationObserver(function(mutations) {
     if (mutations.some(function(m) {

--- a/app/assets/javascripts/kuroko2/instance_linker.js
+++ b/app/assets/javascripts/kuroko2/instance_linker.js
@@ -1,13 +1,12 @@
 jQuery(function ($) {
   var logParent = document.querySelector('#logs tbody');
   var observer = new MutationObserver(function(mutations) {
-    if (mutations.some(x =>
-      x.addedNodes
-        && x.addedNodes instanceof NodeList
-        && x.addedNodes.length > 0
-        && x.type == 'childList'
-      )
-    ) {
+    if (mutations.some(function(m) {
+      return m.addedNodes
+        && m.addedNodes instanceof NodeList
+        && m.addedNodes.length > 0
+        && m.type == 'childList'
+    })) {
       $('td.log').each(function() {
         var logText = $(this).html();
         $(this).html(


### PR DESCRIPTION
instance_linker.js that makes hyperlink from child job instance to parent job instance had not worked correctly. This PR changes it works fine.

logs are appended to `#logs` element by jQuery. So we need to observe changes of the element with [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver).

I'm not sure about JavaScript, if someone have better idea to solve it, please give me comments.

### before

<img width="505" alt="screen shot 2017-06-26 at 11 56 10" src="https://user-images.githubusercontent.com/354940/27557803-bba6e79e-5a6f-11e7-88d0-5cbcacd02e1e.png">

### after

<img width="489" alt="screen shot 2017-06-26 at 13 02 45" src="https://user-images.githubusercontent.com/354940/27557814-cb613f40-5a6f-11e7-978d-c584c55c1446.png">
