### PR TITLE
Use trusty environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rvm:
   - 2.4.1
   - 2.3.3
   - 2.2.6
+before_install:
+  - phantomjs --version
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 cache: bundler
 branches:


### PR DESCRIPTION
refs: https://github.com/cookpad/kuroko2/pull/68#discussion_r124160093

The Trusty environment supports PhantomJS 2.0.
https://docs.travis-ci.com/user/trusty-ci-environment/

@cookpad/dev-infra ?
cc: @inohiro 