### PR TITLE
Load extension modules from top-level

### DIFF
--- a/lib/kuroko2/engine.rb
+++ b/lib/kuroko2/engine.rb
@@ -54,12 +54,12 @@ module Kuroko2
 
       if Kuroko2.config.extensions && Kuroko2.config.extensions.controller
         Kuroko2.config.extensions.controller.each do |extension|
-          Kuroko2::ApplicationController.include(Module.const_get(extension, false))
+          Kuroko2::ApplicationController.include(Object.const_get(extension, false))
         end
       elsif Kuroko2.config.extentions && Kuroko2.config.extentions.controller
         # XXX: Check legacy configuration which was typo
         Kuroko2.config.extentions.controller.each do |extention|
-          Kuroko2::ApplicationController.include(Module.const_get(extention, false))
+          Kuroko2::ApplicationController.include(Object.const_get(extention, false))
         end
       end
     end


### PR DESCRIPTION
`Module.const_get(name, false)` returns `Module::name`, which isn't
intended name for extension modules.
The reason why `Module.const_get('DummyExtension', false)` is working in
test environment is that `Module.const_get('DummyExtension', false)`
invokes autoloading by AS::Dependencies and finds
spec/dummy/lib/dummy_extension.rb and returns `DummyExtension` in
despite of `Module` namespace. In this case, the first call of
`Module.const_get('DummyExtension', false)` returns `DummyExtension`,
but raises `NameError: uninitialized constant Module::DummyExtension`
afterward.

```ruby
Module.const_get('DummyExtension', false) # Return DummyExtension
Module.const_get('DummyExtension', false) # Raise NameError
```

@eisuke @cookpad/dev-infra please review