### PR TITLE
Set process title of command-executor from its command

### DIFF
--- a/lib/autoload/kuroko2/command/executor.rb
+++ b/lib/autoload/kuroko2/command/executor.rb
@@ -28,6 +28,7 @@ module Kuroko2
         Kuroko2.logger = logger
         Kuroko2.logger.info "[#{@hostname}-#{worker_id}] Start worker"
         toggle_worker_status(true)
+        $0 = "command-executor (worker_id=#{worker_id} command=#{@command.class.name})"
 
         sleep worker_id
 


### PR DESCRIPTION
It clarifies which command is running in each process.

Before

```
% ps auxf | grep rails
eagletmt 14149 27.8  0.5 634760 86608 pts/2    Sl+  01:18   0:01  |   | \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14262  0.5  0.5 636820 81064 pts/2    Sl+  01:18   0:00  |   | |   \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14268  0.2  0.4 637104 79348 pts/2    Sl+  01:18   0:00  |   | |   \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14274  0.2  0.4 637248 79412 pts/2    Sl+  01:18   0:00  |   | |   \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14280  0.0  0.4 637084 79264 pts/2    Sl+  01:18   0:00  |   | |   \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14286  0.0  0.4 637120 79452 pts/2    Sl+  01:18   0:00  |   | |   \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14292  0.0  0.4 636816 77304 pts/2    Sl+  01:18   0:00  |   | |   \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 14150 28.0  0.5 627236 80992 pts/2    Sl+  01:18   0:01  |   | \_ ruby ./bin/rails runner Kuroko2::Servers::JobScheduler.new.run
eagletmt 14151 27.2  0.5 631720 85532 pts/2    Sl+  01:18   0:01  |   | \_ ruby ./bin/rails runner Kuroko2::Servers::WorkflowProcessor.new.run
```

After

```
% ps auxf | egrep 'rails|command-executor'
eagletmt 15988  5.9  0.5 633776 85868 pts/2    Sl+  01:24   0:01  |   | \_ ruby ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
eagletmt 16107  0.3  0.5 636264 80800 pts/2    Sl+  01:24   0:00  |   | |   \_ command-executor (worker_id=0 command=Kuroko2::Command::Kill)
eagletmt 16113  0.3  0.4 636584 80408 pts/2    Sl+  01:24   0:00  |   | |   \_ command-executor (worker_id=1 command=Kuroko2::Command::Shell)
eagletmt 16119  0.2  0.4 636548 79148 pts/2    Sl+  01:24   0:00  |   | |   \_ command-executor (worker_id=2 command=Kuroko2::Command::Shell)
eagletmt 16125  0.3  0.4 636552 79116 pts/2    Sl+  01:24   0:00  |   | |   \_ command-executor (worker_id=3 command=Kuroko2::Command::Shell)
eagletmt 16131  0.3  0.4 636592 79104 pts/2    Sl+  01:24   0:00  |   | |   \_ command-executor (worker_id=4 command=Kuroko2::Command::Shell)
eagletmt 16137  0.2  0.4 636380 79056 pts/2    Sl+  01:24   0:00  |   | |   \_ command-executor (worker_id=5 command=Kuroko2::Command::Monitor)
eagletmt 15989  5.8  0.4 626096 80340 pts/2    Sl+  01:24   0:01  |   | \_ ruby ./bin/rails runner Kuroko2::Servers::JobScheduler.new.run
eagletmt 15990  5.7  0.5 627704 82056 pts/2    Sl+  01:24   0:01  |   | \_ ruby ./bin/rails runner Kuroko2::Servers::WorkflowProcessor.new.run
```

----

@cookpad/dev-infra What do you think of this?