### PR TITLE
Add validation checks for adhoc job launch

### DIFF
--- a/app/assets/javascripts/kuroko2/job_definitions.js
+++ b/app/assets/javascripts/kuroko2/job_definitions.js
@@ -76,4 +76,24 @@ jQuery(function ($) {
   });
 
   $('#admin_assignments_user_id').select2();
+
+  $('#adhoc-launch').submit(function(event) {
+      event.preventDefault();
+      var $form = $(this);
+
+      $.ajax({
+          url: $form.attr('action'),
+          type: $form.attr('method'),
+          data: $form.serialize(),
+          timeout: 10000,
+
+          success: function(result, textStatus, xhr) {
+              window.location.href = result.url;
+          },
+
+          error: function(xhr, textStatus, error) {
+              $("#launchAdHocModal-error").show().html("<p>Error: " + xhr.responseJSON.reason + "</p>");
+          }
+      });
+  });
 });

--- a/app/controllers/kuroko2/job_instances_controller.rb
+++ b/app/controllers/kuroko2/job_instances_controller.rb
@@ -15,7 +15,13 @@ class Kuroko2::JobInstancesController < Kuroko2::ApplicationController
     end
 
     @instance = @definition.create_instance(creation_params)
-    redirect_to job_definition_job_instance_path(@definition, @instance)
+    if @definition.errors.any?
+      json = JSON.generate({'reason' => @instance[0] })
+      render json: json, status: :bad_request
+    else
+      json = JSON.generate({'url' => request.protocol + request.host_with_port + job_definition_job_instance_path(@definition, @instance)})
+      render json: json, status: :ok
+    end
   end
 
   def show

--- a/app/views/kuroko2/job_instances/index.html.slim
+++ b/app/views/kuroko2/job_instances/index.html.slim
@@ -38,7 +38,7 @@
 .modal.fade id="launchAdHocModal" tabindex="-1" role="dialog" aria-labelledby="launchAdHocModalLabel"
   .modal-dialog
     .modal-content
-      = form_for @definition, url: job_definition_job_instances_path(@definition), method: :post, html: { role: 'form' } do |form|
+      = form_for @definition, url: job_definition_job_instances_path(@definition), method: :post, html: { role: 'form', id: 'adhoc-launch' } do |form|
 
         .modal-header
           button type="button" class="close" data-dismiss="modal" aria-label="Close"
@@ -47,6 +47,8 @@
           h4.modal-title
             'Launch Job
         .modal-body
+          .col-md-12
+            div id="launchAdHocModal-error"
           .form-group
             = form.label :script
             = form.text_area :script, class: 'form-control script-input', rows: 10, value: @definition.script

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,3 +26,6 @@ en:
       validation_error: 'There are validation errors on script: %{reason}'
       validate_number_of_admins: 'should be at least one person.'
       confirm_active_instances: 'There are a working job instance.'
+    job_instance:
+      script_syntax: 'There are syntax errors on script: %{reason}'
+      validation_error: 'There are validation errors on script: %{reason}'

--- a/spec/controllers/job_instances_controller_spec.rb
+++ b/spec/controllers/job_instances_controller_spec.rb
@@ -25,7 +25,7 @@ describe Kuroko2::JobInstancesController do
     before { post :create, params: { job_definition_id: definition.id }, xhr: true }
 
     it do
-      expect(response).to redirect_to(job_definition_job_instance_path(definition, assigns(:instance)))
+      expect(response).to have_http_status(:ok)
 
       expect(assigns(:definition)).to eq definition
     end
@@ -35,6 +35,22 @@ describe Kuroko2::JobInstancesController do
       before { post :create, params: { job_definition_id: definition.id, job_definition: { script: script } }, xhr: true }
       it 'creates instance in Ad-Hoc script' do
         expect(assigns(:instance).script).to eq script
+      end
+    end
+
+    context 'with Ad-Hoc `empty script` parameter' do
+      let(:script) { "" }
+      before { post :create, params: { job_definition_id: definition.id, job_definition: { script: script } }, xhr: true }
+      it 'creates instance in Ad-Hoc script' do
+        expect(assigns(:instance).script).to eq "noop:\n"
+      end
+    end
+
+    context 'with Ad-Hoc `invalid script` parameter' do
+      let(:script) { "error" }
+      before { post :create, params: { job_definition_id: definition.id, job_definition: { script: script } }, xhr: true }
+      it 'creates instance in Ad-Hoc script' do
+        expect(assigns(:instance)).to eq ["There are syntax errors on script: (line 1) syntax error."]
       end
     end
   end


### PR DESCRIPTION
We expect syntax error when launching adhoc job with wrong syntax scripts in detail page, but we can execute wrong syntax scripts. 

![screenshot from 2017-07-21 00-07-45](https://user-images.githubusercontent.com/795197/28424509-c5de99e0-6da8-11e7-98d4-7df65a29a12f.png)

So, I add syntax validation check for adhoc job launch and show error messages in modal.

![screenshot from 2017-07-21 00-08-03](https://user-images.githubusercontent.com/795197/28424510-c5e341f2-6da8-11e7-9d23-6bb916dc7ae9.png)
