### PR TITLE
Fix deprecated #delete_all conditions parameter

### DIFF
--- a/lib/autoload/kuroko2/workflow/engine.rb
+++ b/lib/autoload/kuroko2/workflow/engine.rb
@@ -125,7 +125,7 @@ module Kuroko2
         token.job_instance.logs.error("(token #{token.uuid}) #{message}")
         token.job_instance.touch(:canceled_at)
 
-        Token.delete_all(job_definition: token.job_definition)
+        Token.where(job_definition: token.job_definition).delete_all
         token.job_instance.logs.warn("(token #{token.uuid}) This job is canceled.")
 
         Kuroko2.logger.error(message)


### PR DESCRIPTION
https://github.com/rails/rails/commit/e7381d289e4f8751dcec9553dcb4d32153bd922b

@cookpad/dev-infra please review