### PR TITLE
Set default rails port number to align `kuroko2.yml` url settings

### DIFF
--- a/app_template.rb
+++ b/app_template.rb
@@ -67,7 +67,7 @@ EOF
 
 
 create_file "Procfile", <<-EOF
-rails: ./bin/rails s
+rails: ./bin/rails s -p 3000
 executor: ./bin/rails runner Kuroko2::Servers::CommandExecutor.new.run
 scheduler: ./bin/rails runner Kuroko2::Servers::JobScheduler.new.run
 processor: ./bin/rails runner Kuroko2::Servers::WorkflowProcessor.new.run


### PR DESCRIPTION
https://github.com/cookpad/kuroko2/issues/81

The port number is 5000 using `foreman start` command.
FYI @cookpad/dev-infra 


