### PR TITLE
Fix google_oauth2 hd check: fix hd option fetching

### DIFF
--- a/app/controllers/kuroko2/sessions_controller.rb
+++ b/app/controllers/kuroko2/sessions_controller.rb
@@ -35,7 +35,7 @@ class Kuroko2::SessionsController < Kuroko2::ApplicationController
   end
 
   def valid_google_hosted_domain?
-    hd = Kuroko2.config.app_authentication.google_oauth2.options.hd
+    hd = Kuroko2.config.app_authentication.google_oauth2.dig(:options, :hd)
     if hd.present?
       hd == auth_hash.extra.id_info.hd
     else

--- a/app/controllers/kuroko2/sessions_controller.rb
+++ b/app/controllers/kuroko2/sessions_controller.rb
@@ -35,7 +35,8 @@ class Kuroko2::SessionsController < Kuroko2::ApplicationController
   end
 
   def valid_google_hosted_domain?
-    hd = Kuroko2.config.app_authentication.google_oauth2.dig(:options, :hd)
+    options = Kuroko2.config.app_authentication.google_oauth2.options
+    hd = options ? options.hd : nil
     if hd.present?
       hd == auth_hash.extra.id_info.hd
     else


### PR DESCRIPTION
Error occurs when setting as follows:
```yml
    google_oauth2:
      client_id: '<%= ENV["GOOGLE_CLIENT_ID"] %>'
      client_secret: '<%= ENV["GOOGLE_CLIENT_SECRET"] %>'
      options:
        #hd: '<%= ENV["GOOGLE_HOSTED_DOMAIN"] %>'
```

```
NoMethodError (undefined method `hd' for nil:NilClass):
kuroko2 (0.4.2) app/controllers/kuroko2/sessions_controller.rb:38:in `valid_google_hosted_domain?'
```

Please merge if no problem 🙏 
