### PR TITLE
Add API for job definitions

### DIFF
--- a/app/controllers/kuroko2/api/application_controller.rb
+++ b/app/controllers/kuroko2/api/application_controller.rb
@@ -15,6 +15,10 @@ class Kuroko2::Api::ApplicationController < ActionController::Base
     respond_with_error(401, 'unauthorized', exception.message)
   end
 
+  rescue_from HTTP::UnprocessableEntity do |exception|
+    respond_with_error(422, 'unprocessable_entity', exception.message)
+  end
+
   rescue_from WeakParameters::ValidationError do |exception|
     respond_with_error(400, 'bad_request', exception.message)
   end

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -10,9 +10,6 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
 
   def create_resource
     definition = Kuroko2::JobDefinition.new(definition_params(params))
-    unless definition.api_allowed?
-      raise_not_allowed(definition)
-    end
     user_ids = admin_id_params(params)
     definition.admins = Kuroko2::User.active.with(user_ids)
 
@@ -35,18 +32,12 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   
   def update_resource
     definition = Kuroko2::JobDefinition.find(params[:id])
-    unless definition.api_allowed?
-      raise_not_allowed(definition)
-    end
     definition.update_attributes(definition_params(params))
     @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
   end
 
   def destroy_resource
     definition = Kuroko2::JobDefinition.find(params[:id])
-    unless definition.api_allowed?
-      raise_not_allowed(definition)
-    end
     definition.destroy
   end
 
@@ -73,9 +64,5 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
       try!(:[], :user_id).
       try!(:reject, &:blank?).
       try!(:map, &:to_i) || []
-  end
-
-  def raise_not_allowed(definition)
-    raise HTTP::Forbidden.new("#{definition.name} is not allowed to be executed via API")
   end
 end

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -4,8 +4,6 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   private
 
   def require_resources
-    definitions = Kuroko2::JobDefinition.all
-    @resources = definitions.map {|definition| Kuroko2::Api::JobDefinitionResource.new(definition) }
   end
 
   def create_resource

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -15,10 +15,10 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
       definition.admins.each do |user|
         user.stars.create(job_definition: definition) if user.google_account?
       end
-      
+
       @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
     else
-      raise WeakParameters::ValidationError.new("#{definition.name}: #{definition.errors.full_messages.join()}")
+      raise HTTP::UnprocessableEntity.new("#{definition.name}: #{definition.errors.full_messages.join()}")
     end
   end
 
@@ -26,11 +26,15 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
     definition = Kuroko2::JobDefinition.find(params[:id])
     @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
   end
-  
+
   def update_resource
     definition = Kuroko2::JobDefinition.find(params[:id])
-    definition.update!(definition_params(params))
-    @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
+
+    if definition.update(definition_params(params))
+      @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
+    else
+      raise HTTP::UnprocessableEntity.new("#{definition.name}: #{definition.errors.full_messages.join()}")
+    end
   end
 
   def definition_params(params)

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -34,11 +34,6 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
     @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
   end
 
-  def destroy_resource
-    definition = Kuroko2::JobDefinition.find(params[:id])
-    definition.destroy
-  end
-
   def definition_params(params)
     params.permit(
       :name,

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -29,7 +29,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   
   def update_resource
     definition = Kuroko2::JobDefinition.find(params[:id])
-    definition.update_attributes(definition_params(params))
+    definition.update!(definition_params(params))
     @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
   end
 

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -12,8 +12,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
     definition.admins = Kuroko2::User.active.with(user_ids)
 
     if definition.save
-      user_ids.each do |user_id|
-        user = Kuroko2::User.active.find(user_id)
+      definition.admins.each do |user|
         user.stars.create(job_definition: definition) if user.google_account?
       end
       

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -1,0 +1,81 @@
+class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationController
+  include Garage::RestfulActions
+
+  private
+
+  def require_resources
+    definitions = Kuroko2::JobDefinition.all
+    @resources = definitions.map {|definition| Kuroko2::Api::JobDefinitionResource.new(definition) }
+  end
+
+  def create_resource
+    definition = Kuroko2::JobDefinition.new(definition_params(params))
+    unless definition.api_allowed?
+      raise_not_allowed(definition)
+    end
+    user_ids = admin_id_params(params)
+    definition.admins = Kuroko2::User.active.with(user_ids)
+
+    if definition.save
+      user_ids.each do |user_id|
+        user = Kuroko2::User.active.find(user_id)
+        user.stars.create(job_definition: definition) if user.google_account?
+      end
+      
+      @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
+    else
+      raise HTTP::Forbidden.new("#{definition.name}: #{definition.errors.full_messages.join()}")
+    end
+  end
+
+  def require_resource
+    definition = Kuroko2::JobDefinition.find(params[:id])
+    @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
+  end
+  
+  def update_resource
+    definition = Kuroko2::JobDefinition.find(params[:id])
+    unless definition.api_allowed?
+      raise_not_allowed(definition)
+    end
+    definition.update_attributes(definition_params(params))
+    @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
+  end
+
+  def destroy_resource
+    definition = Kuroko2::JobDefinition.find(params[:id])
+    unless definition.api_allowed?
+      raise_not_allowed(definition)
+    end
+    definition.destroy
+  end
+
+  def definition_params(params)
+    params.permit(
+      :name,
+      :description,
+      :script,
+      :notify_cancellation,
+      :hipchat_room,
+      :hipchat_notify_finished,
+      :suspended,
+      :prevent_multi,
+      :prevent_multi_on_failure,
+      :hipchat_additional_text,
+      :text_tags,
+      :api_allowed,
+      :slack_channel,
+      :webhook_url)
+  end
+
+  def admin_id_params(params)
+    params.permit(user_id: []).
+      try!(:[], :user_id).
+      try!(:reject, &:blank?).
+      try!(:map, &:to_i) || []
+  end
+
+  def raise_not_allowed(definition)
+    raise HTTP::Forbidden.new("#{definition.name} is not allowed to be executed via API")
+  end
+end

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -19,7 +19,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
       
       @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
     else
-      raise HTTP::Forbidden.new("#{definition.name}: #{definition.errors.full_messages.join()}")
+      raise WeakParameters::ValidationError.new("#{definition.name}: #{definition.errors.full_messages.join()}")
     end
   end
 

--- a/app/errors/http/unprocessable_entity.rb
+++ b/app/errors/http/unprocessable_entity.rb
@@ -1,0 +1,4 @@
+module HTTP
+  class UnprocessableEntity < StandardError
+  end
+end

--- a/app/models/kuroko2/api/job_definition_resource.rb
+++ b/app/models/kuroko2/api/job_definition_resource.rb
@@ -1,0 +1,11 @@
+class Kuroko2::Api::JobDefinitionResource < Kuroko2::Api::ApplicationResource
+  property :id
+
+  property :name
+
+  property :description
+
+  property :script
+
+  delegate :id, :name, :description, :script, to: :model
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,8 +42,8 @@ Kuroko2::Engine.routes.draw do
   get '/osd' => 'dashboard#osd', as: :osd
 
   scope :v1, module: 'api', as: 'api' do
-    resources :job_definitions, path: 'definitions', only: [] do
-      resources :job_instances, path: 'instances', only: [:show, :create]
+    resources :job_definitions, path: 'definitions', only: %w(index create show update destroy) do
+      resources :job_instances, path: 'instances', only: %w(show create)
     end
 
     namespace :stats do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Kuroko2::Engine.routes.draw do
   get '/osd' => 'dashboard#osd', as: :osd
 
   scope :v1, module: 'api', as: 'api' do
-    resources :job_definitions, path: 'definitions', only: %w(index create show update destroy) do
+    resources :job_definitions, path: 'definitions', only: %w(create show update destroy) do
       resources :job_instances, path: 'instances', only: %w(show create)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Kuroko2::Engine.routes.draw do
   get '/osd' => 'dashboard#osd', as: :osd
 
   scope :v1, module: 'api', as: 'api' do
-    resources :job_definitions, path: 'definitions', only: %w(create show update destroy) do
+    resources :job_definitions, path: 'definitions', only: %w(create show update) do
       resources :job_instances, path: 'instances', only: %w(show create)
     end
 

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+describe 'job_definitions' do
+  let(:service_name) { :test_client_name }
+  let(:secret_key) { 'secret_key' }
+  let(:env) do
+    {
+      accept: 'application/json',
+      authorization: "Basic #{Base64.encode64("#{service_name}:#{secret_key}")}",
+    }
+  end
+  let(:result) { JSON.parse(response.body) }
+
+  describe 'GET /v1/definitions' do
+    let(:definition) do
+      create(:job_definition, script: 'noop:', api_allowed: true)
+    end
+
+    before do
+      definition
+    end
+
+    it 'returns definitions' do
+      get "/v1/definitions", params: {}, env: env
+      expect(result).to eq(
+        [{
+          'id' => definition.id,
+          'name' => definition.name,
+          'description' => definition.description,
+          'script' => definition.script
+        }]
+      )
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'POST /v1/definitions' do
+    let(:params) do
+      {
+        name: "test",
+        description: "description",
+        script: "noop:",
+        notify_cancellation: 1,
+        hipchat_room: "",
+        hipchat_notify_finished: 1,
+        suspended: false,
+        prevent_multi: 1,
+        hipchat_additional_text: "",
+        text_tags: "",
+        api_allowed: 1,
+        slack_channel: "",
+        webhook_url: "",
+        user_id: [user.id],
+      }
+    end
+
+    let(:user) do
+      create(:user)
+    end
+
+    it 'creates a new definition' do
+      expect {
+        post "/v1/definitions", params: params, env: env
+      }.to change {
+        Kuroko2::JobDefinition.count
+      }.by(1)
+      expect(result['name']).to eq(params[:name])
+      expect(result['description']).to eq(params[:description])
+      expect(result['script']).to eq(params[:script])
+      expect(response.status).to eq(201)
+    end
+  end
+
+  describe 'GET /v1/definitions/:id' do
+    let(:definition) do
+      create(:job_definition, script: 'noop:', api_allowed: true)
+    end
+
+    it 'returns a definition' do
+      get "/v1/definitions/#{definition.id}", params: {}, env: env
+      expect(result).to eq(
+        {
+          'id' => definition.id,
+          'name' => definition.name,
+          'description' => definition.description,
+          'script' => definition.script
+        }
+      )
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'PUT /v1/definitions/:id' do
+    let(:definition) do
+      create(:job_definition, script: 'noop:', api_allowed: true)
+    end
+
+    let(:params) do
+      {
+        name: "test",
+        description: "description",
+        script: "echo: Hello",
+        notify_cancellation: 1,
+        hipchat_room: "",
+        hipchat_notify_finished: 1,
+        suspended: false,
+        prevent_multi: 1,
+        hipchat_additional_text: "",
+        text_tags: "",
+        api_allowed: 1,
+        slack_channel: "",
+        webhook_url: "",
+      }
+    end
+
+    it 'updates a definition' do
+      put "/v1/definitions/#{definition.id}", params: params, env: env
+      expect(response.status).to eq(204)
+    end
+  end
+
+  describe 'DELETE /v1/definitions/:id' do
+    let(:definition) do
+      create(:job_definition, script: 'noop:', api_allowed: true)
+    end
+
+    it 'deletes a definition' do
+      expect {
+        delete "/v1/definitions/#{definition.id}", params: {}, env: env
+      }.to change {
+        Kuroko2::JobDefinition.count
+      }.by(0)
+    end
+  end
+end

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -12,39 +12,67 @@ describe 'job_definitions' do
   let(:result) { JSON.parse(response.body) }
 
   describe 'POST /v1/definitions' do
-    let(:params) do
-      {
-        name: "test",
-        description: "description",
-        script: "noop:",
-        notify_cancellation: 1,
-        hipchat_room: "",
-        hipchat_notify_finished: 1,
-        suspended: false,
-        prevent_multi: 1,
-        hipchat_additional_text: "",
-        text_tags: "",
-        api_allowed: 1,
-        slack_channel: "",
-        webhook_url: "",
-        user_id: [user.id],
-      }
-    end
-
+    
     let(:user) do
       create(:user)
     end
 
-    it 'creates a new definition' do
-      expect {
+    context 'with valid parameters' do
+      let(:params) do
+        {
+          name: "test",
+          description: "description",
+          script: "noop:",
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          text_tags: "",
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+          user_id: [user.id],
+        }
+      end
+
+      it 'creates a new definition' do
+        expect {
+          post "/v1/definitions", params: params, env: env
+        }.to change {
+          Kuroko2::JobDefinition.count
+        }.by(1)
+        expect(result['name']).to eq(params[:name])
+        expect(result['description']).to eq(params[:description])
+        expect(result['script']).to eq(params[:script])
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context 'with invalid parameters' do
+      let(:params) do
+        {
+          description: "description",
+          script: "noop:",
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          text_tags: "",
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+          user_id: [user.id],
+        }
+      end
+
+      it 'returns Http Status: 400' do
         post "/v1/definitions", params: params, env: env
-      }.to change {
-        Kuroko2::JobDefinition.count
-      }.by(1)
-      expect(result['name']).to eq(params[:name])
-      expect(result['description']).to eq(params[:description])
-      expect(result['script']).to eq(params[:script])
-      expect(response.status).to eq(201)
+        expect(response.status).to eq(400)
+      end
     end
   end
 
@@ -72,27 +100,54 @@ describe 'job_definitions' do
       create(:job_definition, script: 'noop:', api_allowed: true)
     end
 
-    let(:params) do
-      {
-        name: "test",
-        description: "description",
-        script: "echo: Hello",
-        notify_cancellation: 1,
-        hipchat_room: "",
-        hipchat_notify_finished: 1,
-        suspended: false,
-        prevent_multi: 1,
-        hipchat_additional_text: "",
-        text_tags: "",
-        api_allowed: 1,
-        slack_channel: "",
-        webhook_url: "",
-      }
+    context 'with valid parameters' do
+      let(:params) do
+        {
+          name: "test",
+          description: "description",
+          script: "echo: Hello",
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          text_tags: "",
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+        }
+      end
+
+      it 'updates a definition' do
+        put "/v1/definitions/#{definition.id}", params: params, env: env
+        expect(response.status).to eq(204)
+      end
     end
 
-    it 'updates a definition' do
-      put "/v1/definitions/#{definition.id}", params: params, env: env
-      expect(response.status).to eq(204)
+    context 'with a undefined definition' do
+      let(:params) do
+        {
+          name: "test",
+          description: "description",
+          script: "echo: Hello",
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          text_tags: "",
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+        }
+      end
+
+      it 'returns Http Status: 404' do
+        put "/v1/definitions/#{definition.id + 1}", params: params, env: env
+        expect(response.status).to eq(404)
+      end
     end
   end
 end

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -125,6 +125,32 @@ describe 'job_definitions' do
       end
     end
 
+    context 'with invalid parameters' do
+      let(:params) do
+        {
+          name: "test",
+          description: "description",
+          script: nil,
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          text_tags: "",
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+        }
+      end
+
+      it 'updates a definition' do
+        expect {
+          put "/v1/definitions/#{definition.id}", params: params, env: env
+        }.to raise_error
+      end
+    end
+
     context 'with a undefined definition' do
       let(:params) do
         {

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -95,18 +95,4 @@ describe 'job_definitions' do
       expect(response.status).to eq(204)
     end
   end
-
-  describe 'DELETE /v1/definitions/:id' do
-    let(:definition) do
-      create(:job_definition, script: 'noop:', api_allowed: true)
-    end
-
-    it 'deletes a definition' do
-      expect {
-        delete "/v1/definitions/#{definition.id}", params: {}, env: env
-      }.to change {
-        Kuroko2::JobDefinition.count
-      }.by(0)
-    end
-  end
 end

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -11,29 +11,6 @@ describe 'job_definitions' do
   end
   let(:result) { JSON.parse(response.body) }
 
-  describe 'GET /v1/definitions' do
-    let(:definition) do
-      create(:job_definition, script: 'noop:', api_allowed: true)
-    end
-
-    before do
-      definition
-    end
-
-    it 'returns definitions' do
-      get "/v1/definitions", params: {}, env: env
-      expect(result).to eq(
-        [{
-          'id' => definition.id,
-          'name' => definition.name,
-          'description' => definition.description,
-          'script' => definition.script
-        }]
-      )
-      expect(response.status).to eq(200)
-    end
-  end
-
   describe 'POST /v1/definitions' do
     let(:params) do
       {

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -12,7 +12,7 @@ describe 'job_definitions' do
   let(:result) { JSON.parse(response.body) }
 
   describe 'POST /v1/definitions' do
-    
+
     let(:user) do
       create(:user)
     end
@@ -69,9 +69,9 @@ describe 'job_definitions' do
         }
       end
 
-      it 'returns Http Status: 400' do
+      it 'returns Http Status: 422' do
         post "/v1/definitions", params: params, env: env
-        expect(response.status).to eq(400)
+        expect(response.status).to eq(422)
       end
     end
   end
@@ -130,7 +130,7 @@ describe 'job_definitions' do
         {
           name: "test",
           description: "description",
-          script: nil,
+          script: "noop",
           notify_cancellation: 1,
           hipchat_room: "",
           hipchat_notify_finished: 1,
@@ -144,10 +144,9 @@ describe 'job_definitions' do
         }
       end
 
-      it 'updates a definition' do
-        expect {
-          put "/v1/definitions/#{definition.id}", params: params, env: env
-        }.to raise_error
+      it 'returns Http Status: 422' do
+        put "/v1/definitions/#{definition.id}", params: params, env: env
+        expect(response.status).to eq(422)
       end
     end
 


### PR DESCRIPTION
I added API for job definitions.

You can use this as follow.

```
# index
$ curl -s -u user:password http://example.com/v1/definitions

# create
$ curl -s -u user:password -XPOST http://example.com/v1/definitions \
  -d "name=job_name" \
  -d "description=your_description" \
  -d "script=noop:" \
  -d "notify_cancellation=1" \
  -d "hipchat_room=" \
  -d "hipchat_notify_finished=1"\
  -d "suspended=false" \
  -d "prevent_multi=1" \
  -d "hipchat_additional_text=" \
  -d "text_tags=" \
  -d "api_allowed=1" \
  -d "slack_channel=" \
  -d "webhook_url=" \
  -d "user_id[]=1"
 
# show
$ curl -s -u user:password http://example.com/v1/definitions/1

# update
$ curl -s -u user:password -XPUT http://example.com/v1/definitions/1 \
  -d "name=job_name" \
  -d "description=your_description" \
  -d "script=noop:" \
  -d "notify_cancellation=1" \
  -d "hipchat_room=" \
  -d "hipchat_notify_finished=1"\
  -d "suspended=false" \
  -d "prevent_multi=1" \
  -d "hipchat_additional_text=" \
  -d "text_tags=" \
  -d "api_allowed=1" \
  -d "slack_channel=" \
  -d "webhook_url="

# delete
$ curl -s -u user:password -XDELETE http://example.com/v1/definitions/1
```