### PR TITLE
Add option for shell executer

### DIFF
--- a/lib/autoload/kuroko2/command/shell.rb
+++ b/lib/autoload/kuroko2/command/shell.rb
@@ -81,10 +81,15 @@ module Kuroko2
         job_definition_name = execution.context['meta'].try(:[], 'job_definition_name').to_s
         job_instance_id     = execution.context['meta'].try(:[], 'job_instance_id').to_s
 
-        env.reverse_merge!(
-          'HOME'                        => ENV['HOME'],
-          'PATH'                        => ENV['PATH'],
-          'LANG'                        => ENV['LANG'],
+        if Kuroko2.config.fetch("executer", {}).fetch("take_over_env_from_parent_process", false)
+          env.reverse_merge!(ENV)
+        else
+          env.reverse_merge!(
+            'HOME' => ENV['HOME'],
+            'PATH' => ENV['PATH'],
+            'LANG' => ENV['LANG'],
+          )
+        end.reverse_merge!(
           'KUROKO2_LAUNCHED_TIME'       => launched_time,
           'KUROKO2_JOB_DEFINITION_ID'   => job_definition_id,
           'KUROKO2_JOB_DEFINITION_NAME' => job_definition_name,

--- a/spec/dummy/config/kuroko2.yml
+++ b/spec/dummy/config/kuroko2.yml
@@ -4,6 +4,8 @@ default: &default
     delivery_method: 'test'
   execution_logger:
     type: 'Void'
+  executer:
+    take_over_env_from_parent_process: false
   custom_tasks:
     custom_task1: 'CustomTask1'
   notifiers:


### PR DESCRIPTION
take over environment variables from parent process.

To need ENV from parent when mounted as rails engine.