### PR TITLE
Add button to duplicate job definition

### DIFF
--- a/app/controllers/kuroko2/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/job_definitions_controller.rb
@@ -33,8 +33,15 @@ class Kuroko2::JobDefinitionsController < Kuroko2::ApplicationController
   end
 
   def new
-    @definition = Kuroko2::JobDefinition.new
-    @definition.admins << current_user
+    dup_from = Kuroko2::JobDefinition.find_by(id: params[:dup_from])
+    if dup_from.present?
+      @definition = dup_from.dup
+      @definition.admins = dup_from.admins
+      @definition.tags = dup_from.tags
+    else
+      @definition = Kuroko2::JobDefinition.new
+    end
+    @definition.admins << current_user unless @definition.admins.include?(current_user)
   end
 
   def create

--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -81,7 +81,7 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
   end
 
   def text_tags
-    tags.pluck(:name).join(',')
+    tags.map(&:name).join(',')
   end
 
   def text_tags=(text_tags)

--- a/app/views/kuroko2/job_definitions/show.html.slim
+++ b/app/views/kuroko2/job_definitions/show.html.slim
@@ -80,9 +80,11 @@
 
       .box-footer
         .row
-          .col-md-6
+          .col-md-4
             = link_to 'Edit Job definition', edit_job_definition_path(@definition), class: 'btn btn-default btn-block', role: 'button'
-          .col-md-6
+          .col-md-4
+            = link_to 'Duplicate Job definition', new_job_definition_path(dup_from: @definition.id), class: 'btn btn-default btn-block', role: 'button'
+          .col-md-4
             = link_to 'Destroy Job definition', @definition, method: :delete, class: 'btn btn-default btn-block', role: 'button', data: { confirm: 'Are you sure?' }
   .col-md-5#schedules-holder
     = render template: 'kuroko2/job_schedules/index'

--- a/spec/controllers/job_definitions_controller_spec.rb
+++ b/spec/controllers/job_definitions_controller_spec.rb
@@ -38,6 +38,68 @@ describe Kuroko2::JobDefinitionsController do
 
       expect(assigns(:definition)).to be_new_record
     end
+
+    context 'with dup_from params' do
+      subject! { get :new, params: { dup_from: definition.id } }
+      it do
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template('new')
+
+        expect(assigns(:definition)).to be_new_record
+        expect(assigns(:definition).name).to eq definition.name
+        expect(assigns(:definition).admins).to eq definition.admins + [controller.current_user]
+        expect(assigns(:definition).tags).to eq definition.tags
+      end
+
+      context 'with current_user and aother admin user' do
+        let!(:admin_user) { create(:user) }
+        let!(:definition) { create(:job_definition, admins: [admin_user, controller.current_user]) }
+        it do
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template('new')
+
+          expect(assigns(:definition)).to be_new_record
+          expect(assigns(:definition).name).to eq definition.name
+          expect(assigns(:definition).admins).to match_array [admin_user, controller.current_user]
+        end
+
+        context 'with only another admin user' do
+          let!(:definition) { create(:job_definition, admins: [admin_user]) }
+          it do
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template('new')
+
+            expect(assigns(:definition)).to be_new_record
+            expect(assigns(:definition).name).to eq definition.name
+            expect(assigns(:definition).admins).to match_array [admin_user, controller.current_user]
+          end
+        end
+      end
+
+      context 'with tags' do
+        let!(:definition) { create(:job_definition, text_tags: 'First,Second') }
+        it do
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template('new')
+
+          expect(assigns(:definition)).to be_new_record
+          expect(assigns(:definition).name).to eq definition.name
+          expect(assigns(:definition).text_tags).to eq definition.text_tags
+        end
+      end
+
+      context 'with invalid id' do
+        subject! { get :new, params: { dup_from: 'invalid' } }
+        it do
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template('new')
+
+          expect(assigns(:definition)).to be_new_record
+          expect(assigns(:definition).name).to be_blank
+          expect(assigns(:definition).admins).to eq [controller.current_user]
+        end
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/job_definitions_controller_spec.rb
+++ b/spec/controllers/job_definitions_controller_spec.rb
@@ -51,7 +51,7 @@ describe Kuroko2::JobDefinitionsController do
         expect(assigns(:definition).tags).to eq definition.tags
       end
 
-      context 'with current_user and aother admin user' do
+      context 'with current_user and another admin user' do
         let!(:admin_user) { create(:user) }
         let!(:definition) { create(:job_definition, admins: [admin_user, controller.current_user]) }
         it do


### PR DESCRIPTION
Add button for duplicate job definition to Job Definition Details page.
This allows us to duplicate the definition for similarly jobs.
On press the button, it open New Job Definition page with pre-filled the definition.

Before:
![before](https://user-images.githubusercontent.com/22152877/35082516-a6249b4c-fc5d-11e7-9362-ea08d127c12c.png)
After:
![after](https://user-images.githubusercontent.com/22152877/35082518-aa8a2c10-fc5d-11e7-9f3b-9ad42bdbfebd.png)