### PR TITLE
Add execution history for worker

### DIFF
--- a/app/controllers/kuroko2/execution_histories_controller.rb
+++ b/app/controllers/kuroko2/execution_histories_controller.rb
@@ -1,0 +1,73 @@
+class Kuroko2::ExecutionHistoriesController < Kuroko2::ApplicationController
+  def index
+    @histories = histories.page(params[:page])
+  end
+
+  def timeline
+  end
+
+  def dataset
+    set_period
+    @histories = histories.where('started_at < ?', @end_at).where('finished_at > ?', @start_at)
+  end
+
+  private
+
+  def query_params
+    params.permit(:queue, :hostname)
+  end
+
+  def histories
+    histories = Kuroko2::ExecutionHistory.ordered.includes(:job_definition, :job_instance)
+
+    queue = query_params[:queue]
+    histories = histories.where(queue: queue) if queue.present?
+
+    hostname = query_params[:hostname]
+    histories = histories.where(hostname: hostname) if hostname.present?
+
+    histories
+  end
+
+  def period_params
+    params.permit(:period, :end_at, :start_at)
+  end
+
+  def end_at
+    if period_params[:end_at].present?
+      begin
+        return period_params[:end_at].to_datetime
+      rescue ArgumentError
+        # do nothing
+      end
+    end
+    Time.current
+  end
+
+  def start_at
+    if period_params[:start_at].present?
+      begin
+        return period_params[:start_at].to_datetime
+      rescue ArgumentError
+        # do nothing
+      end
+    end
+    case period_params[:period]
+    when /\A(\d+)m\z/
+      $1.to_i.minutes.ago(@end_at)
+    when /\A(\d+)h\z/
+      $1.to_i.hours.ago(@end_at)
+    when /\A(\d+)d\z/
+      $1.to_i.days.ago(@end_at)
+    when /\A(\d+)w\z/
+      $1.to_i.weeks.ago(@end_at)
+    else
+      1.hour.ago(@end_at)
+    end
+  end
+
+  def set_period
+    @end_at = end_at
+    @start_at = start_at
+  end
+end

--- a/app/models/kuroko2/execution_history.rb
+++ b/app/models/kuroko2/execution_history.rb
@@ -1,0 +1,8 @@
+class Kuroko2::ExecutionHistory < Kuroko2::ApplicationRecord
+  include Kuroko2::TableNameCustomizable
+
+  belongs_to :job_definition
+  belongs_to :job_instance
+
+  scope :ordered, -> { order(started_at: :desc) }
+end

--- a/app/views/kuroko2/execution_histories/dataset.json.jbuilder
+++ b/app/views/kuroko2/execution_histories/dataset.json.jbuilder
@@ -1,0 +1,10 @@
+json.start @start_at.strftime('%Y-%m-%d %H:%M:%S')
+json.end   @end_at.strftime('%Y-%m-%d %H:%M:%S')
+json.data do
+  json.array! @histories do |history|
+    json.id history.id
+    json.content "<a href='#{job_definition_job_instance_path(history.job_definition, history.job_instance)}'>##{history.job_definition.id} #{h(history.job_definition.name)}</a>"
+    json.start history.started_at.strftime('%Y-%m-%d %H:%M:%S')
+    json.end history.finished_at.strftime('%Y-%m-%d %H:%M:%S')
+  end
+end

--- a/app/views/kuroko2/execution_histories/index.html.slim
+++ b/app/views/kuroko2/execution_histories/index.html.slim
@@ -1,0 +1,39 @@
+- content_for :title, 'Execution Histories'
+- content_for :content_title do
+  <i class="fa fa-history"></i> Execution Histories
+- @scope = @histories
+
+.box#execution-histories
+  .box-header
+    .row
+      .col-md-9
+        h3.box-title Execution Histories
+      .col-md-3.right-button
+        = link_to raw('<i class="fa fa-clock-o"></i> Show Timeline'), timeline_execution_histories_path(params.permit(:queue, :hostname)), class: 'btn btn-default btn-small btn-block js-to-timeline'
+  - if @histories.empty?
+    .box-body
+      .text-muted.well.well-sm.no-shadow There are no execution histories yet.
+  - else
+    .box-body.table-responsive
+      table.table.table-hover
+        thead
+          tr
+            th.col-md-2 Hostname
+            th.col-md-1 WID
+            th.col-md-2 Queue
+            th.col-md-2 Job
+            th.col-md-2 Command
+            th.col-md-2 Started at
+            th.col-md-1 Elapsed Time
+        tbody
+          - for history in @histories
+            tr
+              td= history.hostname
+              td= history.worker_id
+              td= history.queue
+              td.no-decorate= link_to "##{history.job_definition.id} #{history.job_definition.name}", job_definition_job_instance_path(history.job_definition, history.job_instance)
+              td= history.shell
+              td= l(history.started_at, format: :short)
+              td= distance_of_time(history.started_at, history.finished_at)
+    .box-footer#pagination
+      = paginate @histories, theme: 'list'

--- a/app/views/kuroko2/execution_histories/timeline.html.slim
+++ b/app/views/kuroko2/execution_histories/timeline.html.slim
@@ -1,0 +1,33 @@
+- content_for :title, "Execution Timeline"
+- content_for :content_title do
+    <i class="fa fa-clock-o"></i> Execution Timeline
+
+.row
+  .col-md-12
+    .box
+      .box-header
+        nav class="navbar navbar-default"
+          div class="container-fluid"
+            div class="navbar-header"
+              a class="navbar-brand" href="#" Period
+            div class="" id="period-nav"
+              ul class="nav navbar-nav"
+                li class="#{params[:period] == '30m' ? 'active' : ''}"
+                  = link_to '30 minutes', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '30m'))
+                li class="#{params[:period] == '1h' || !params[:period] ? 'active' : ''}"
+                  = link_to '1 hour', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '1h'))
+                li class="#{params[:period] == '3h' ? 'active' : ''}"
+                  = link_to '3 hours', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '3h'))
+                li class="#{params[:period] == '6h' ? 'active' : ''}"
+                  = link_to '6 hours', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '6h'))
+                li class="#{params[:period] == '12h' ? 'active' : ''}"
+                  = link_to '12 hours', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '12h'))
+                li class="#{params[:period] == '1d' ? 'active' : ''}"
+                  = link_to '1 day', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '1d'))
+                li class="#{params[:period] == '3d' ? 'active' : ''}"
+                  = link_to '3 days', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '3d'))
+                li class="#{params[:period] == '1w' ? 'active' : ''}"
+                  = link_to '1 week', timeline_execution_histories_path(params.permit(:queue, :hostname, :end_at).merge(period: '1w'))
+
+      .box-body
+        div#timeline data-dataset-path="#{dataset_execution_histories_path(params.permit(:queue, :hostname, :start_at, :end_at, :period))}"

--- a/app/views/kuroko2/workers/index.html.slim
+++ b/app/views/kuroko2/workers/index.html.slim
@@ -17,9 +17,9 @@
           th.col-md-1 &nbsp;
         - for worker in @workers
           tr
-            td= worker.hostname
+            td.no-decorate= link_to worker.hostname, execution_histories_path(hostname: worker.hostname)
             td= worker.worker_id
-            td= worker.queue
+            td.no-decorate= link_to worker.queue, execution_histories_path(queue: worker.queue)
             td
               - if worker.working
                 span.label.label-primary WORKING

--- a/bin/cleanup_old_execution_histories.rb
+++ b/bin/cleanup_old_execution_histories.rb
@@ -1,0 +1,9 @@
+old_histories = Kuroko2::ExecutionHistory.where('finished_at < ?', 2.weeks.ago)
+
+count = old_histories.count
+
+Kuroko2::ExecutionHistories.transaction do
+  old_histories.destroy_all
+end
+
+puts "Destroyed #{count} histories"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,11 @@ Kuroko2::Engine.routes.draw do
     get :dataset, action: :dataset, on: :collection, defaults: { format: 'json' }
   end
 
+  resources :execution_histories, only: :index do
+    get :timeline, action: :timeline, on: :collection
+    get 'timeline/dataset', action: :dataset, on: :collection, defaults: { format: 'json' }, as: 'dataset'
+  end
+
   get '/sign_in', to: 'sessions#new', as: 'sign_in'
   delete '/sign_out', to: 'sessions#destroy', as: 'sign_out'
 

--- a/db/migrate/031_create_execution_histories.rb
+++ b/db/migrate/031_create_execution_histories.rb
@@ -1,0 +1,19 @@
+class CreateExecutionHistories < ActiveRecord::Migration[5.0]
+  def change
+    create_table :execution_histories do |t|
+      t.string :hostname, limit: 180
+      t.integer :worker_id, limit: 1
+      t.string :queue, limit: 180, default: "@default", null: false
+      t.integer :job_definition_id, null: false
+      t.integer :job_instance_id, null: false
+      t.text :shell, null: false
+      t.datetime :started_at, null: false
+      t.datetime :finished_at, null: false
+    end
+
+    add_column :executions, :hostname, :string, limit: 180
+    add_column :executions, :worker_id, :integer, limit: 1
+
+    add_index :execution_histories, [:worker_id, :started_at], using: :btree
+  end
+end

--- a/lib/autoload/kuroko2/command/shell.rb
+++ b/lib/autoload/kuroko2/command/shell.rb
@@ -32,6 +32,7 @@ module Kuroko2
       def do_execute(execution)
         begin
           @worker.update_column(:execution_id, execution.id)
+          execution.update(hostname: @hostname, worker_id: @worker_id)
 
           invoke(execution)
         rescue SystemCallError => e

--- a/lib/autoload/kuroko2/workflow/task/execute.rb
+++ b/lib/autoload/kuroko2/workflow/task/execute.rb
@@ -61,6 +61,17 @@ module Kuroko2
               instance.logs.error(message)
             end
 
+            Kuroko2::ExecutionHistory.create(
+              hostname: execution.hostname,
+              worker_id: execution.worker_id,
+              queue: execution.queue,
+              job_definition: execution.job_definition,
+              job_instance: execution.job_instance,
+              shell: execution.shell,
+              started_at: execution.started_at,
+              finished_at: execution.finished_at,
+            )
+
             execution.with_lock do
               execution.destroy
               execution.success? ? :next : :failure

--- a/spec/controllers/execution_histories_controller_spec.rb
+++ b/spec/controllers/execution_histories_controller_spec.rb
@@ -1,0 +1,177 @@
+require 'rails_helper'
+
+describe Kuroko2::ExecutionHistoriesController do
+  routes { Kuroko2::Engine.routes }
+
+  before { sign_in }
+
+  let!(:histories) { create_list(:execution_history, 3) }
+
+  describe '#index' do
+    subject! { get :index }
+
+    it do
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template('index')
+
+      expect(assigns(:histories)).to match_array histories
+    end
+
+    context 'with valid queue' do
+      subject! { get :index, params: { queue: '@default' } }
+
+      it do
+        expect(assigns(:histories)).to match_array histories
+      end
+    end
+
+    context 'with unknown queue' do
+      subject! { get :index, params: { queue: 'unknown' } }
+
+      it do
+        expect(assigns(:histories)).to be_empty
+      end
+    end
+
+    context 'with valid hostname' do
+      subject! { get :index, params: { hostname: 'rspec' } }
+
+      it do
+        expect(assigns(:histories)).to match_array histories
+      end
+    end
+
+    context 'with unknown hostname' do
+      subject! { get :index, params: { hostname: 'unknown' } }
+
+      it do
+        expect(assigns(:histories)).to be_empty
+      end
+    end
+  end
+
+  describe '#timeline' do
+    subject! { get :timeline }
+
+    it do
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template('timeline')
+    end
+  end
+
+  describe '#dataset' do
+    subject! { get :dataset, xhr: true }
+
+    it do
+      expect(response).to have_http_status(:ok)
+
+      expect(assigns(:histories)).to match_array histories
+      expect(assigns(:end_at)).not_to be_nil
+      expect(assigns(:start_at)).to eq(assigns(:end_at) - 1.hour)
+    end
+
+    context 'with valid queue' do
+      subject! { get :dataset, xhr: true, params: { queue: '@default' } }
+
+      it do
+        expect(assigns(:histories)).to match_array histories
+      end
+    end
+
+    context 'with unknown queue' do
+      subject! { get :dataset, xhr: true, params: { queue: 'unknown' } }
+
+      it do
+        expect(assigns(:histories)).to be_empty
+      end
+    end
+
+    context 'with valid hostname' do
+      subject! { get :dataset, xhr: true, params: { hostname: 'rspec' } }
+
+      it do
+        expect(assigns(:histories)).to match_array histories
+      end
+    end
+
+    context 'with unknown hostname' do
+      subject! { get :dataset, xhr: true, params: { hostname: 'unknown' } }
+
+      it do
+        expect(assigns(:histories)).to be_empty
+      end
+    end
+
+    context 'with period' do
+      subject! { get :dataset, xhr: true, params: { period: period }}
+
+      context '30 minutes' do
+        let(:period) { '30m' }
+        it do
+          expect(assigns(:histories)).to match_array histories
+          expect(assigns(:start_at)).to eq(assigns(:end_at) - 30.minutes)
+        end
+      end
+      context '1 hour' do
+        let(:period) { '1h' }
+        it do
+          expect(assigns(:histories)).to match_array histories
+          expect(assigns(:start_at)).to eq(assigns(:end_at) - 1.hour)
+        end
+      end
+
+      context '1 day' do
+        let(:period) { '1d' }
+        it do
+          expect(assigns(:histories)).to match_array histories
+          expect(assigns(:start_at)).to eq(assigns(:end_at) - 1.day)
+        end
+      end
+
+      context '1 week' do
+        let(:period) { '1w' }
+        it do
+          expect(assigns(:histories)).to match_array histories
+          expect(assigns(:start_at)).to eq(assigns(:end_at) - 1.week)
+        end
+      end
+    end
+
+    context 'with end_at' do
+      let(:end_at) { Time.current + 5.minute }
+      subject! { get :dataset, xhr: true, params: { end_at: end_at } }
+
+      it do
+        expect(assigns(:histories)).to match_array histories
+        expect(assigns(:end_at).strftime("%d-%m-%Y %H:%M:%S")).to eq end_at.strftime("%d-%m-%Y %H:%M:%S")
+      end
+
+      context 'with invalid' do
+        let(:end_at) { 'invalid' }
+
+        it do
+          expect(assigns(:histories)).to match_array histories
+        end
+      end
+    end
+
+    context 'with start_at' do
+      let(:start_at) { 1.hour.ago(Time.current) }
+      subject! { get :dataset, xhr: true, params: { start_at: start_at } }
+
+      it do
+        expect(assigns(:histories)).to match_array histories
+        expect(assigns(:start_at).strftime("%d-%m-%Y %H:%M:%S")).to eq start_at.strftime("%d-%m-%Y %H:%M:%S")
+      end
+
+      context 'with invalid' do
+        let(:start_at) { 'invalid' }
+
+        it do
+          expect(assigns(:histories)).to match_array histories
+          expect(assigns(:start_at)).to eq(assigns(:end_at) - 1.hour)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 30) do
+ActiveRecord::Schema.define(version: 31) do
 
   create_table "admin_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer "user_id", null: false
@@ -18,6 +18,18 @@ ActiveRecord::Schema.define(version: 30) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["user_id", "job_definition_id"], name: "user_id", unique: true
+  end
+
+  create_table "execution_histories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string "hostname", limit: 180
+    t.integer "worker_id", limit: 1
+    t.string "queue", limit: 180, default: "@default", null: false
+    t.integer "job_definition_id", null: false
+    t.integer "job_instance_id", null: false
+    t.text "shell", null: false
+    t.datetime "started_at", null: false
+    t.datetime "finished_at", null: false
+    t.index ["worker_id", "started_at"], name: "index_kuroko2_execution_histories_on_worker_id_and_started_at"
   end
 
   create_table "executions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
@@ -38,6 +50,8 @@ ActiveRecord::Schema.define(version: 30) do
     t.datetime "mailed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "hostname", limit: 180
+    t.integer "worker_id", limit: 1
     t.index ["job_definition_id", "token_id"], name: "index_kuroko2_executions_on_job_definition_id_and_token_id", unique: true
     t.index ["started_at"], name: "started_at"
   end

--- a/spec/factories/execution_history_factory.rb
+++ b/spec/factories/execution_history_factory.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :execution_history, class: Kuroko2::ExecutionHistory do
+    hostname 'rspec'
+    worker_id 1
+    queue '@default'
+
+    job_definition { create(:job_definition) }
+    job_instance { create(:job_instance, job_definition: job_definition) }
+
+    shell 'echo $NAME'
+
+    started_at { Time.current }
+    finished_at { Time.current }
+  end
+end

--- a/spec/features/execution_histories_spec.rb
+++ b/spec/features/execution_histories_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'Shows execution histories', type: :feature do
+  before { sign_in }
+
+  let!(:worker) { create(:worker, hostname: 'rspec') }
+  let(:job_definition) { create(:job_definition) }
+  let!(:histories) { create_list(:execution_history, 3, job_definition: job_definition) }
+
+  it 'shows list of execution histories' do
+    visit kuroko2.workers_path
+    expect(page).to have_content('Kuroko Workers')
+    expect(page).to have_content('rspec')
+    expect(page).to have_content('@default')
+
+    click_on 'rspec'
+
+    expect(page).to have_content('Execution Histories')
+    expect(page).to have_selector('#execution-histories table tbody tr', count: 3)
+    expect(page).to have_content('rspec')
+    expect(page).to have_content('@default')
+    expect(page).to have_content(job_definition.name)
+  end
+
+  it 'shows timeline of execution histories' do
+    visit kuroko2.execution_histories_path(hostname: 'rspec')
+
+    expect(page).to have_content('Execution Histories')
+    expect(page).to have_content('Show Timeline')
+
+    click_on 'Show Timeline'
+
+    expect(page).to have_content('Execution Timeline')
+    expect(page).to have_content(job_definition.name)
+  end
+end

--- a/spec/models/execution_history_spec.rb
+++ b/spec/models/execution_history_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+describe Kuroko2::ExecutionHistory do
+end

--- a/spec/workflow/task/execute_spec.rb
+++ b/spec/workflow/task/execute_spec.rb
@@ -41,6 +41,7 @@ module Kuroko2::Workflow::Task
 
         expect(Kuroko2::Execution.all.size).to eq 0
         expect(Kuroko2::Log.all.count).to eq 1
+        expect(Kuroko2::ExecutionHistory.all.size).to eq 1
       end
     end
 


### PR DESCRIPTION
Add pages to show execution history for worker. You can check executed jobs at specific time.

#### Worker Logs page

![worker_logs_page](https://user-images.githubusercontent.com/22152877/35424681-84c5c796-0298-11e8-8da9-1b4e149c684e.png)

#### Worker Logs Timeline page

![worker_timeline_page](https://user-images.githubusercontent.com/22152877/35424688-8f1356f0-0298-11e8-9f95-2330b8f25aa0.png)