### PR TITLE
add ruby-2.5 to CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ branches:
     - master
 rvm:
   - ruby-head
-  - 2.4.1
-  - 2.3.3
-  - 2.2.6
+  - 2.5
+  - 2.4
+  - 2.3
+  - 2.2
 before_install:
   - phantomjs --version
 addons:


### PR DESCRIPTION
Now 2.5 is stable; ruby-head will be 2.6.

FYI you can omit teeny versions in .travis.yml