### PR TITLE
Enable to use custom kuroko_runner script

### DIFF
--- a/lib/autoload/kuroko2/workflow/task/kuroko_runner.rb
+++ b/lib/autoload/kuroko2/workflow/task/kuroko_runner.rb
@@ -15,8 +15,20 @@ module Kuroko2
 
         def shell
           rails = Rails.root.join('bin/rails').to_s
-          kuroko_script = Kuroko2::Engine.root.join("bin/#{option}.rb")
           "bundle exec #{rails} runner -e #{Rails.env} #{kuroko_script}"
+        end
+
+        private
+
+        # Try to find target script in mounted project at first.
+        # If not exist, fallback to engine
+        def kuroko_script
+          script_in_project = Rails.root.join("bin/#{option}.rb")
+          if File.exist?(script_in_project)
+            script_in_project
+          else
+            Kuroko2::Engine.root.join("bin/#{option}.rb")
+          end
         end
       end
     end

--- a/spec/dummy/bin/script_in_project.rb
+++ b/spec/dummy/bin/script_in_project.rb
@@ -1,0 +1,1 @@
+puts "It works!"

--- a/spec/workflow/task/kuroko_runner_spec.rb
+++ b/spec/workflow/task/kuroko_runner_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+module Kuroko2::Workflow::Task
+  describe KurokoRunner do
+    describe '#shell' do
+      let(:definition) { create(:job_definition, script: "kuroko_runner: #{option}") }
+      let(:instance) { create(:job_instance, job_definition: definition) }
+      let(:node) { Kuroko2::Workflow::Node.new(:kuroko_runner, option) }
+      let(:token) { build(:token, job_definition: definition, job_instance: instance) }
+
+      let(:shell) { KurokoRunner.new(node, token).shell }
+
+      context 'with script in engine' do
+        let(:option) { 'cleanup_old_instances' }
+
+        it { expect(shell).to include("kuroko2/bin/#{option}.rb") }
+      end
+
+      context 'with script in project' do
+        let(:option) { 'script_in_project' }
+
+        it { expect(shell).to include("spec/dummy/bin/#{option}.rb") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Let kuroko2 user enable to run their own script on kuroko_runner.

This patch will add '#{project_path}/bin' to kuroko_runner script search path.
It prefers script in mounted project than in the engine.

How do you think @cookpad/dev-infra ?