### PR TITLE
Support multiple hosted domains

### DIFF
--- a/app/controllers/kuroko2/sessions_controller.rb
+++ b/app/controllers/kuroko2/sessions_controller.rb
@@ -38,7 +38,7 @@ class Kuroko2::SessionsController < Kuroko2::ApplicationController
     options = Kuroko2.config.app_authentication.google_oauth2.options
     hd = options ? options.hd : nil
     if hd.present?
-      hd == auth_hash.extra.id_info.hd
+      Array(hd).include?(auth_hash.extra.id_info.hd)
     else
       true
     end


### PR DESCRIPTION
kuroko2 can accept only single hosted domain. This PR enable kuroko2 to accept multiple hosted domains like omniauth-google-oauth2.(https://github.com/zquestz/omniauth-google-oauth2/blob/master/lib/omniauth/strategies/google_oauth2.rb#L208)

example conf
```yaml
  app_authentication:
    google_oauth2:
      client_id: '<%= ENV["GOOGLE_CLIENT_ID"] %>'
      client_secret: '<%= ENV["GOOGLE_CLIENT_SECRET"] %>'
      options:
        hd:
          - example.org
          - example.com
```