### PR TITLE
Let all job instance be target of cleanup_old_instance

### DIFF
--- a/bin/cleanup_old_instances.rb
+++ b/bin/cleanup_old_instances.rb
@@ -1,4 +1,7 @@
-old_instances = Kuroko2::JobInstance.where('finished_at < ?', 3.months.ago)
+target_date = 3.months.ago
+old_instances = Kuroko2::JobInstance
+  .where('finished_at < ?', target_date)
+  .or(Kuroko2::JobInstance.where('canceled_at < ?', target_date))
 
 count = old_instances.count
 

--- a/kuroko2.gemspec
+++ b/kuroko2.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'the_garage'
   s.add_dependency 'weak_parameters'
 
-  s.add_development_dependency "mysql2"
+  s.add_development_dependency 'mysql2', '< 0.5'
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
`bin/cleanup_old_instances` script try to delete only job instance which finished successfully.
I think the job instances which was finished with canceled or error state should be included.

proposed code will produce the sql like below:

```sql
SELECT `job_instances`.* FROM `job_instances` WHERE (((finished_at < '2017-12-27 04:57:31.648294') OR (canceled_at < '2017-12-27 04:57:31.648294')) OR (errored_at < '2017-12-27 04:57:31.648294')
```

@cookpad/dev-infra Could you review this?