### PR TITLE
Let destroy old job instances in batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ script:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.5

--- a/bin/cleanup_old_instances.rb
+++ b/bin/cleanup_old_instances.rb
@@ -6,7 +6,7 @@ Kuroko2::JobInstance
   .or(Kuroko2::JobInstance.where('canceled_at < ?', target_date))
   .order(id: :asc)
   .in_batches do |old_instances|
-  count += old_instances.count
+  count += old_instances.size
   Kuroko2::JobInstance.transaction do
     old_instances.destroy_all
   end

--- a/bin/cleanup_old_instances.rb
+++ b/bin/cleanup_old_instances.rb
@@ -1,12 +1,15 @@
 target_date = 3.months.ago
-old_instances = Kuroko2::JobInstance
+count = 0
+
+Kuroko2::JobInstance
   .where('finished_at < ?', target_date)
   .or(Kuroko2::JobInstance.where('canceled_at < ?', target_date))
-
-count = old_instances.count
-
-Kuroko2::JobInstance.transaction do
-  old_instances.destroy_all
+  .order(id: :asc)
+  .in_batches do |old_instances|
+  count += old_instances.count
+  Kuroko2::JobInstance.transaction do
+    old_instances.destroy_all
+  end
 end
 
 puts "Destroyed #{count} instances"


### PR DESCRIPTION
Follow up of #107

#107 script will affect another batch execution if it has old job instances a lot.
To reduce the effect estimated on production service, let the deletion process be worked in batch(per 1000).

@cookpad/dev-infra please review this :)