### PR TITLE
Don't use Rails 5.2 temporarily

### DIFF
--- a/kuroko2.gemspec
+++ b/kuroko2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "bin/*.rb"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 5.0.0.1"
+  s.add_dependency "rails", ">= 5.0.0.1", '< 5.2'
   s.add_dependency "kaminari"
   s.add_dependency "chrono"
   s.add_dependency "hashie"


### PR DESCRIPTION
Rails 5.2 removed `halt_callback_chains_on_return_false`.

```
NoMethodError: undefined method `halt_callback_chains_on_return_false=' for ActiveSupport:Module
/home/travis/build/cookpad/kuroko2/spec/dummy/config/initializers/new_framework_defaults.rb:23:in `<top (required)>'
...
```