### PR TITLE
Fix job definition star button

### DIFF
--- a/app/assets/javascripts/kuroko2/job_definitions.js
+++ b/app/assets/javascripts/kuroko2/job_definitions.js
@@ -12,6 +12,7 @@ jQuery(function ($) {
 
         var elem = $('<a class="star" rel="nofollow" data-remote="true" data-method="post"><i class="fa fa-star-o"></i></a>')
           .attr("href", definitionsPath + "/" + definitionId + "/stars")
+          .attr("data-definitions-path", definitionsPath)
           .attr("data-definition-id", definitionId);
 
         $(currentTarget).replaceWith(elem);
@@ -24,6 +25,7 @@ jQuery(function ($) {
         var elem = $('<a class="star" rel="nofollow" data-remote="true" data-method="delete"><i class="fa fa-star"></i></a>')
           .attr("href", definitionsPath + "/" + definitionId + "/stars/" + starId)
           .attr("data-star-id", starId)
+          .attr("data-definitions-path", definitionsPath)
           .attr("data-definition-id", definitionId);
 
         $(currentTarget).replaceWith(elem);


### PR DESCRIPTION
<img width="1040" alt="2018-05-15 16 32 27" src="https://user-images.githubusercontent.com/6443461/40042937-ec89f38c-585d-11e8-8833-3fbe9aeb2d5e.png">

When I clicked job definitions star icon twice, the star icon link was broken like `undefined/1/stars/11`.
I fixed that link to be `definitions/1/stars/11`