### PR TITLE
Alter {users,job_definitions}.id to bigint

### DIFF
--- a/db/migrate/033_alter_key_and_index_to_bigint.rb
+++ b/db/migrate/033_alter_key_and_index_to_bigint.rb
@@ -1,0 +1,37 @@
+class AlterKeyAndIndexToBigint < ActiveRecord::Migration[5.0]
+  def up
+    change_column :job_definitions, :id, :bigint, auto_increment: true
+    change_column :admin_assignments, :job_definition_id, :bigint
+    change_column :execution_histories, :job_definition_id, :bigint
+    change_column :executions, :job_definition_id, :bigint
+    change_column :job_definition_tags, :job_definition_id, :bigint
+    change_column :job_instances, :job_definition_id, :bigint
+    change_column :job_schedules, :job_definition_id, :bigint
+    change_column :job_suspend_schedules, :job_definition_id, :bigint
+    change_column :memory_expectancies, :job_definition_id, :bigint
+    change_column :stars, :job_definition_id, :bigint
+    change_column :tokens, :job_definition_id, :bigint
+
+    change_column :users, :id, :bigint, auto_increment: true
+    change_column :admin_assignments, :user_id, :bigint
+    change_column :stars, :user_id, :bigint
+  end
+
+  def down
+    change_column :job_definitions, :id, :int, auto_increment: true
+    change_column :admin_assignments, :job_definition_id, :int
+    change_column :execution_histories, :job_definition_id, :int
+    change_column :executions, :job_definition_id, :int
+    change_column :job_definition_tags, :job_definition_id, :int
+    change_column :job_instances, :job_definition_id, :int
+    change_column :job_schedules, :job_definition_id, :int
+    change_column :job_suspend_schedules, :job_definition_id, :int
+    change_column :memory_expectancies, :job_definition_id, :int
+    change_column :stars, :job_definition_id, :int
+    change_column :tokens, :job_definition_id, :int
+
+    change_column :users, :id, :int, auto_increment: true
+    change_column :admin_assignments, :user_id, :int
+    change_column :stars, :user_id, :int
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 32) do
+ActiveRecord::Schema.define(version: 33) do
 
   create_table "admin_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "job_definition_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["user_id", "job_definition_id"], name: "user_id", unique: true
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 32) do
     t.string "hostname", limit: 180
     t.integer "worker_id", limit: 1
     t.string "queue", limit: 180, default: "@default", null: false
-    t.integer "job_definition_id", null: false
+    t.bigint "job_definition_id", null: false
     t.integer "job_instance_id", null: false
     t.text "shell", null: false
     t.datetime "started_at", null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 32) do
 
   create_table "executions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
+    t.bigint "job_definition_id"
     t.integer "job_definition_version"
     t.integer "job_instance_id"
     t.integer "token_id"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 32) do
   end
 
   create_table "job_definition_tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id", null: false
+    t.bigint "job_definition_id", null: false
     t.integer "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 32) do
     t.index ["tag_id"], name: "job_definition_tags_tag_id"
   end
 
-  create_table "job_definitions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+  create_table "job_definitions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer "version", default: 0, null: false
     t.string "name", limit: 180, null: false
     t.text "description", null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 32) do
   end
 
   create_table "job_instances", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
+    t.bigint "job_definition_id"
     t.integer "job_definition_version"
     t.text "script"
     t.datetime "finished_at"
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 32) do
   end
 
   create_table "job_schedules", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
+    t.bigint "job_definition_id"
     t.string "cron", limit: 180
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -107,109 +107,7 @@ ActiveRecord::Schema.define(version: 32) do
   end
 
   create_table "job_suspend_schedules", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.string "cron", limit: 180
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id", "cron"], name: "kuroko2_suspend_schedules_definition_id_cron_idx", unique: true
-  end
-
-  create_table "admin_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["user_id", "job_definition_id"], name: "user_id", unique: true
-  end
-
-  create_table "execution_histories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180
-    t.integer "worker_id", limit: 1
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.integer "job_definition_id", null: false
-    t.integer "job_instance_id", null: false
-    t.text "shell", null: false
-    t.datetime "started_at", null: false
-    t.datetime "finished_at", null: false
-    t.index ["worker_id", "started_at"], name: "index_kuroko2_execution_histories_on_worker_id_and_started_at"
-  end
-
-  create_table "executions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.integer "job_instance_id"
-    t.integer "token_id"
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.text "shell", null: false
-    t.text "context", null: false
-    t.integer "pid"
-    t.text "output", limit: 4294967295
-    t.integer "exit_status", limit: 2
-    t.integer "term_signal", limit: 1
-    t.datetime "started_at"
-    t.datetime "finished_at"
-    t.datetime "mailed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "hostname", limit: 180
-    t.integer "worker_id", limit: 1
-    t.index ["job_definition_id", "token_id"], name: "index_kuroko2_executions_on_job_definition_id_and_token_id", unique: true
-    t.index ["started_at"], name: "started_at"
-  end
-
-  create_table "job_definition_tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id", null: false
-    t.integer "tag_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id", "tag_id"], name: "kuroko2_definition_tag_idx", unique: true
-    t.index ["tag_id"], name: "job_definition_tags_tag_id"
-  end
-
-  create_table "job_definitions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "version", default: 0, null: false
-    t.string "name", limit: 180, null: false
-    t.text "description", null: false
-    t.text "script", null: false
-    t.boolean "suspended", default: false, null: false
-    t.integer "prevent_multi", default: 1, null: false
-    t.boolean "notify_cancellation", default: true, null: false
-    t.string "hipchat_room", limit: 180, default: "", null: false
-    t.boolean "hipchat_notify_finished", default: true, null: false
-    t.string "hipchat_additional_text", limit: 180
-    t.string "slack_channel", limit: 180, default: "", null: false
-    t.boolean "api_allowed", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text "webhook_url"
-    t.index ["name"], name: "name"
-  end
-
-  create_table "job_instances", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.text "script"
-    t.datetime "finished_at"
-    t.datetime "canceled_at"
-    t.datetime "error_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean "retrying", default: false, null: false
-    t.index ["finished_at", "canceled_at", "job_definition_id"], name: "job_instance_idx"
-    t.index ["job_definition_id"], name: "index_kuroko2_job_instances_on_job_definition_id"
-  end
-
-  create_table "job_schedules", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
-    t.string "cron", limit: 180
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["job_definition_id", "cron"], name: "kuroko2_schedules_definition_id_cron_idx", unique: true
-  end
-
-  create_table "job_suspend_schedules", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_definition_id"
+    t.bigint "job_definition_id"
     t.string "cron", limit: 180
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -235,7 +133,7 @@ ActiveRecord::Schema.define(version: 32) do
 
   create_table "memory_expectancies", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer "expected_value", default: 0, null: false
-    t.integer "job_definition_id"
+    t.bigint "job_definition_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["job_definition_id"], name: "index_kuroko2_memory_expectancies_on_job_definition_id"
@@ -255,8 +153,8 @@ ActiveRecord::Schema.define(version: 32) do
   end
 
   create_table "stars", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "job_definition_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["user_id", "job_definition_id"], name: "index_kuroko2_stars_on_user_id_and_job_definition_id", unique: true
@@ -275,7 +173,7 @@ ActiveRecord::Schema.define(version: 32) do
 
   create_table "tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
+    t.bigint "job_definition_id"
     t.integer "job_definition_version"
     t.integer "job_instance_id"
     t.integer "parent_id"
@@ -290,110 +188,7 @@ ActiveRecord::Schema.define(version: 32) do
     t.index ["status"], name: "status"
   end
 
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "provider", limit: 180, default: "google_oauth2", null: false
-    t.string "uid", limit: 180, null: false
-    t.string "name", limit: 180, default: "", null: false
-    t.string "email", limit: 180, null: false
-    t.string "first_name", limit: 180, default: "", null: false
-    t.string "last_name", limit: 180, default: "", null: false
-    t.string "image", limit: 180, default: "", null: false
-    t.datetime "suspended_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["email"], name: "email"
-    t.index ["uid", "suspended_at"], name: "uid_2"
-    t.index ["uid"], name: "uid", unique: true
-  end
-
-  create_table "workers", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180, null: false
-    t.integer "worker_id", limit: 1, null: false
-    t.string "queue", limit: 180, default: "@default", null: false
-    t.boolean "working", default: false, null: false
-    t.integer "execution_id"
-    t.boolean "suspendable", default: false, null: false
-    t.boolean "suspended", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["hostname", "worker_id"], name: "hostname", unique: true
-  end
-
-  create_table "logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_instance_id"
-    t.string "level", limit: 10
-    t.text "message", limit: 4294967295
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["job_instance_id"], name: "job_instance_id"
-  end
-
-  create_table "memory_consumption_logs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "job_instance_id"
-    t.integer "value", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_instance_id"], name: "index_kuroko2_memory_consumption_logs_on_job_instance_id"
-  end
-
-  create_table "memory_expectancies", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "expected_value", default: 0, null: false
-    t.integer "job_definition_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_definition_id"], name: "index_kuroko2_memory_expectancies_on_job_definition_id"
-  end
-
-  create_table "process_signals", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "hostname", limit: 180, default: "", null: false
-    t.integer "pid", null: false
-    t.integer "number", limit: 1, default: 15, null: false
-    t.datetime "started_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text "message"
-    t.integer "execution_id"
-    t.index ["execution_id"], name: "index_kuroko2_process_signals_on_execution_id"
-    t.index ["hostname", "started_at"], name: "hostname_started_at"
-  end
-
-  create_table "stars", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.integer "user_id", null: false
-    t.integer "job_definition_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["user_id", "job_definition_id"], name: "index_kuroko2_stars_on_user_id_and_job_definition_id", unique: true
-  end
-
-  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "name", limit: 100, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_kuroko2_tags_on_name", unique: true
-  end
-
-  create_table "ticks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.datetime "at"
-  end
-
-  create_table "tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
-    t.string "uuid", limit: 36, null: false
-    t.integer "job_definition_id"
-    t.integer "job_definition_version"
-    t.integer "job_instance_id"
-    t.integer "parent_id"
-    t.text "script", null: false
-    t.string "path", limit: 180, default: "/", null: false
-    t.integer "status", default: 0, null: false
-    t.text "message", null: false
-    t.text "context", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["parent_id"], name: "parent_id"
-    t.index ["status"], name: "status"
-  end
-
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string "provider", limit: 180, default: "google_oauth2", null: false
     t.string "uid", limit: 180, null: false
     t.string "name", limit: 180, default: "", null: false


### PR DESCRIPTION
There is the problem that some tables has different type of primary key from
its installed:

- before 0.2.0: using unsigned int for primary key
- after 0.2.0: using signed int for primary key

This problem was made by fa75b20e463f0f95d74aa3e50ac6b35e1596f26b.

This makes hard to keep consistency of code / infra.
For instance, we need to care about 2 types of primary when adding foreign key.
Actually, this is already blocker of https://github.com/cookpad/kuroko2/pull/110

To solve the problem, this patch proposes to alter these primary key to
bigint, which is next default type of rails.

Please review this @cookpad/dev-infra 
cc @takonomura 