### PR TITLE
Do not allow ci failure with ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,3 @@ script:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.5


### PR DESCRIPTION
Intruduced: https://github.com/cookpad/kuroko2/pull/108

It seems works well now...?

FYI @cookpad/dev-infra 