### PR TITLE
Drop Ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.5
   - 2.4
   - 2.3
-  - 2.2
 before_install:
   - phantomjs --version
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## lastest(master branch)
 
+- Drop Ruby 2.2 support
+
 ## v0.5.0
 
 - Use MutationObserver to observe log for work instance_linker.js correctly [#68](https://github.com/cookpad/kuroko2/pull/68)


### PR DESCRIPTION
Ruby 2.2 is EOL. [Ref](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/)

FYI @cookpad/dev-infra 