### PR TITLE
update omniauth-google-oauth2

### DIFF
--- a/kuroko2.gemspec
+++ b/kuroko2.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-store', '~> 0.0.4'
   s.add_dependency 'dotenv-rails', '~> 0.11.1'
   s.add_dependency 'serverengine', '~> 1.5.7'
-  s.add_dependency 'omniauth-google-oauth2', '~> 0.2.4'
+  s.add_dependency 'omniauth-google-oauth2', '~> 0.6.0'
 
   s.add_dependency 'html-pipeline'
   s.add_dependency 'commonmarker', '>= 0.17.8'


### PR DESCRIPTION
Google+ is shutdown on March 7, 2019.
https://developers.google.com/+/integrations-shutdown
`omniauth-google-oauth2-0.2.4` is requesting Google+ OAuth scopes(`plus.people.getOpenIdConnect`).
so I update `omniauth-google-oauth2-0.6.0`.
This version is not use Google+ API endpoints.
https://github.com/zquestz/omniauth-google-oauth2/blob/master/CHANGELOG.md#060---2018-12-28
