### PR TITLE
Prevent from propagating env vars at outside of fork task scope

### DIFF
--- a/lib/autoload/kuroko2/workflow/task/fork.rb
+++ b/lib/autoload/kuroko2/workflow/task/fork.rb
@@ -43,9 +43,9 @@ module Kuroko2
         end
 
         def create_child_token(child_node:, env: {})
-          attributes = token.attributes.except('id', 'uuid', 'script', 'path', 'message', 'created_at', 'updated_at')
-          attributes = attributes.merge(uuid: SecureRandom.uuid, parent: token, script: child_node.to_script, path: '/')
-          attributes['context']['ENV'] = (attributes['context']['ENV'] || {}).merge(env)
+          attributes = token.attributes.except('id', 'uuid', 'script', 'path', 'message', 'created_at', 'updated_at', 'context')
+          attributes = attributes.merge(uuid: SecureRandom.uuid, parent: token, script: child_node.to_script, path: '/', context: token.context.deep_dup)
+          attributes[:context]['ENV'] = (attributes[:context]['ENV'] || {}).merge(env)
 
           Token.create!(attributes).tap do |created|
             fork_children_ids << created.id

--- a/spec/workflow/engine_spec.rb
+++ b/spec/workflow/engine_spec.rb
@@ -126,6 +126,7 @@ module Kuroko2::Workflow
             parallel_fork: 3
               noop: noop1
               noop: noop2
+            noop: noop3
           EOF
         end
 
@@ -172,6 +173,13 @@ module Kuroko2::Workflow
           expect(token.path).to eq '/1-parallel_fork'
           expect(parallel_tokens.map(&:path)).to all(eq('/0-sequence/1-noop'))
           expect(parallel_tokens.map(&:status_name)).to all(eq('finished'))
+
+          subject.process(token)
+          expect(token.path).to eq '/2-noop'
+          expect(token.status_name).to eq 'working'
+          expect(token.context['ENV']['GLOBAL_ENV']).to eq('g')
+          expect(token.context['ENV']['KUROKO2_PARALLEL_FORK_SIZE']).to be_nil
+          expect(token.context['ENV']['KUROKO2_PARALLEL_FORK_INDEX']).to be_nil
 
           subject.process_all
           expect(Kuroko2::Token.all.count).to eq 0


### PR DESCRIPTION
Since deserialized context value of Token model by getting through
AttributeSet#attributes is passed by reference, additional env values
passed to create_child_token method overwrite a context which a token
instance variable has. This cause unintentional env values propagation
like KUROKO2_PARALLEL_FORK_SIZE at outside of the fork task scope.

To avoid this, use the deep copy for context value instead.

@cookpad/infra please review