### PR TITLE
Extend API to allow job definitions to be managed with an automation tool.

### DIFF
--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -42,6 +42,10 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
     end
   end
 
+  def destroy_resource
+    @resource.destroy
+  end
+
   def definition_params(params)
     params.permit(
       :name,

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -4,6 +4,11 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   private
 
   def require_resources
+    definitions = Kuroko2::JobDefinition.includes(:tags)
+    if params[:tags].present?
+      definitions = definitions.tagged_by(params[:tags])
+    end
+    @resources = definitions.ordered.map { |definition| Kuroko2::Api::JobDefinitionResource.new(definition) }
   end
 
   def create_resource

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -15,6 +15,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
     definition = Kuroko2::JobDefinition.new(definition_params(params))
     user_ids = admin_id_params(params)
     definition.admins = Kuroko2::User.active.with(user_ids)
+    definition.tags = tags(params)
 
     if definition.save_and_record_revision
       definition.admins.each do |user|
@@ -34,6 +35,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
 
   def update_resource
     definition = Kuroko2::JobDefinition.find(params[:id])
+    definition.tags = tags(params)
 
     if definition.update_and_record_revision(definition_params(params))
       @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
@@ -62,6 +64,13 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
       :api_allowed,
       :slack_channel,
       :webhook_url)
+  end
+
+  def tags(params)
+    tag_strings = params.permit(tags: [])[:tags] || []
+    tag_strings.map do |name|
+      Kuroko2::Tag.find_or_create_by(name: name)
+    end
   end
 
   def admin_id_params(params)

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -4,7 +4,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   private
 
   def require_resources
-    definitions = Kuroko2::JobDefinition.includes(:tags)
+    definitions = Kuroko2::JobDefinition.includes(:tags, :job_schedules)
     if params[:tags].present?
       definitions = definitions.tagged_by(params[:tags])
     end
@@ -30,7 +30,7 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   end
 
   def require_resource
-    definition = Kuroko2::JobDefinition.find(params[:id])
+    definition = Kuroko2::JobDefinition.includes(:tags, :job_schedules).find(params[:id])
     @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
   end
 

--- a/app/controllers/kuroko2/api/job_definitions_controller.rb
+++ b/app/controllers/kuroko2/api/job_definitions_controller.rb
@@ -15,17 +15,17 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
     definition = Kuroko2::JobDefinition.new(definition_params(params))
     user_ids = admin_id_params(params)
     definition.admins = Kuroko2::User.active.with(user_ids)
-    definition.job_schedules = job_schedules(params)
     definition.tags = tags(params)
 
     if definition.save_and_record_revision
+      definition.job_schedules = job_schedules(params, definition)
       definition.admins.each do |user|
         user.stars.create(job_definition: definition) if user.google_account?
       end
 
       @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
     else
-      raise HTTP::UnprocessableEntity.new("#{definition.name}: #{definition.errors.full_messages.join()}")
+      raise HTTP::UnprocessableEntity.new("#{definition.name}: #{definition.errors.full_messages.join}")
     end
   end
 
@@ -36,13 +36,13 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
 
   def update_resource
     definition = Kuroko2::JobDefinition.find(params[:id])
-    definition.job_schedules = job_schedules(params)
     definition.tags = tags(params)
+    definition.job_schedules = job_schedules(params, definition)
 
     if definition.update_and_record_revision(definition_params(params))
       @resource = Kuroko2::Api::JobDefinitionResource.new(definition)
     else
-      raise HTTP::UnprocessableEntity.new("#{definition.name}: #{definition.errors.full_messages.join()}")
+      raise HTTP::UnprocessableEntity.new("#{definition.name}: #{definition.errors.full_messages.join}")
     end
   end
 
@@ -69,17 +69,17 @@ class Kuroko2::Api::JobDefinitionsController < Kuroko2::Api::ApplicationControll
   end
 
   def tags(params)
-    tag_strings = params.permit(tags: [])[:tags] || []
+    tag_strings = params.permit(tags: []).fetch(:tags, [])
     tag_strings.map do |name|
       Kuroko2::Tag.find_or_create_by(name: name)
     end
   end
 
-  def job_schedules(params)
-    cron_strings = params.permit(job_schedules: [])[:job_schedules] || []
+  def job_schedules(params, definition)
+    cron_strings = params.permit(cron: []).fetch(:cron, [])
     cron_strings.map do |cron|
-      schedule = Kuroko2::JobSchedule.find_or_create_by(cron: cron)
-      raise HTTP::UnprocessableEntity.new("#{cron}: #{schedule.errors.full_messages.join()}") unless schedule.valid?
+      schedule = definition.job_schedules.find_or_create_by(cron: cron)
+      raise HTTP::UnprocessableEntity.new("#{cron}: #{schedule.errors.full_messages.join}") unless schedule.valid?
       schedule
     end
   end

--- a/app/models/kuroko2/api/job_definition_resource.rb
+++ b/app/models/kuroko2/api/job_definition_resource.rb
@@ -7,5 +7,11 @@ class Kuroko2::Api::JobDefinitionResource < Kuroko2::Api::ApplicationResource
 
   property :script
 
+  property :tags
+
+  def tags
+    model.tags.pluck(:name)
+  end
+
   delegate :id, :name, :description, :script, :destroy, to: :model
 end

--- a/app/models/kuroko2/api/job_definition_resource.rb
+++ b/app/models/kuroko2/api/job_definition_resource.rb
@@ -12,11 +12,11 @@ class Kuroko2::Api::JobDefinitionResource < Kuroko2::Api::ApplicationResource
   property :job_schedules
 
   def tags
-    model.tags.pluck(:name)
+    model.tags.map(&:name)
   end
 
   def job_schedules
-    model.job_schedules.pluck(:cron)
+    model.job_schedules.map(&:cron)
   end
 
   delegate :id, :name, :description, :script, :destroy, to: :model

--- a/app/models/kuroko2/api/job_definition_resource.rb
+++ b/app/models/kuroko2/api/job_definition_resource.rb
@@ -9,13 +9,13 @@ class Kuroko2::Api::JobDefinitionResource < Kuroko2::Api::ApplicationResource
 
   property :tags
 
-  property :job_schedules
+  property :cron
 
   def tags
     model.tags.map(&:name)
   end
 
-  def job_schedules
+  def cron
     model.job_schedules.map(&:cron)
   end
 

--- a/app/models/kuroko2/api/job_definition_resource.rb
+++ b/app/models/kuroko2/api/job_definition_resource.rb
@@ -7,5 +7,5 @@ class Kuroko2::Api::JobDefinitionResource < Kuroko2::Api::ApplicationResource
 
   property :script
 
-  delegate :id, :name, :description, :script, to: :model
+  delegate :id, :name, :description, :script, :destroy, to: :model
 end

--- a/app/models/kuroko2/api/job_definition_resource.rb
+++ b/app/models/kuroko2/api/job_definition_resource.rb
@@ -9,8 +9,14 @@ class Kuroko2::Api::JobDefinitionResource < Kuroko2::Api::ApplicationResource
 
   property :tags
 
+  property :job_schedules
+
   def tags
     model.tags.pluck(:name)
+  end
+
+  def job_schedules
+    model.job_schedules.pluck(:cron)
   end
 
   delegate :id, :name, :description, :script, :destroy, to: :model

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Kuroko2::Engine.routes.draw do
   get '/osd' => 'dashboard#osd', as: :osd
 
   scope :v1, module: 'api', as: 'api' do
-    resources :job_definitions, path: 'definitions', only: %w(create show update index) do
+    resources :job_definitions, path: 'definitions', except: %w(new edit) do
       resources :job_instances, path: 'instances', only: %w(show create)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Kuroko2::Engine.routes.draw do
   get '/osd' => 'dashboard#osd', as: :osd
 
   scope :v1, module: 'api', as: 'api' do
-    resources :job_definitions, path: 'definitions', only: %w(create show update) do
+    resources :job_definitions, path: 'definitions', only: %w(create show update index) do
       resources :job_instances, path: 'instances', only: %w(show create)
     end
 

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -35,7 +35,7 @@ describe 'job_definitions' do
           "description" => job_definition.description,
           "script" => job_definition.script,
           "tags" => [],
-          "job_schedules"=>[],
+          "cron"=>[],
         )
       end
     end
@@ -163,7 +163,7 @@ describe 'job_definitions' do
           description: "description",
           script: "noop:",
           user_id: [user.id],
-          job_schedules: ["0 0 1,15 * *", "0 */7 * * *"],
+          cron: ["0 0 1,15 * *", "0 */7 * * *"],
         }
 
         expect {
@@ -175,7 +175,7 @@ describe 'job_definitions' do
 
         expect(response.status).to eq(201)
 
-        params[:job_schedules] = ["0 0 1 * *"]
+        params[:cron] = ["0 0 1 * *"]
         put "/v1/definitions/#{result['id']}", params: params, env: env
         expect(response.status).to eq(204)
         expect(Kuroko2::JobSchedule.count).to eq 1
@@ -189,7 +189,7 @@ describe 'job_definitions' do
           description: "description",
           script: "noop:",
           user_id: [user.id],
-          job_schedules: ["0 0 1,15 * *", "0 */7 * * *"],
+          cron: ["0 0 1,15 * *", "0 */7 * * *", "0 0 * * *"],
         }
       end
 
@@ -198,12 +198,13 @@ describe 'job_definitions' do
           post "/v1/definitions", params: params, env: env
         }.to change {
           Kuroko2::JobSchedule.count
-        }.by(2)
+        }.by(3)
 
         expect(response.status).to eq(201)
         expect(result['name']).to eq(params[:name])
         expect(result['description']).to eq(params[:description])
         expect(result['script']).to eq(params[:script])
+        expect(result['cron']).to eq(params[:cron])
       end
 
       context 'an invalid schedule' do
@@ -213,7 +214,7 @@ describe 'job_definitions' do
             description: "description",
             script: "noop:",
             user_id: [user.id],
-            job_schedules: ["hotdogs"],
+            cron: ["hotdogs"],
           }
         end
 
@@ -266,7 +267,7 @@ describe 'job_definitions' do
           'description' => definition.description,
           'script' => definition.script,
           'tags' => ['taggy-mc-tagface'],
-          'job_schedules' => [schedule.cron],
+          'cron' => [schedule.cron],
         }
       )
       expect(response.status).to eq(200)

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -34,6 +34,7 @@ describe 'job_definitions' do
           "name" => job_definition.name,
           "description" => job_definition.description,
           "script" => job_definition.script,
+          "tags" => [],
         )
       end
     end
@@ -127,8 +128,9 @@ describe 'job_definitions' do
   end
 
   describe 'GET /v1/definitions/:id' do
+    let(:tag) { Kuroko2::Tag.create(name: "taggy-mc-tagface") }
     let(:definition) do
-      create(:job_definition, script: 'noop:', api_allowed: true)
+      create(:job_definition, script: 'noop:', api_allowed: true, tags: [tag])
     end
 
     it 'returns a definition' do
@@ -138,7 +140,8 @@ describe 'job_definitions' do
           'id' => definition.id,
           'name' => definition.name,
           'description' => definition.description,
-          'script' => definition.script
+          'script' => definition.script,
+          'tags' => ['taggy-mc-tagface'],
         }
       )
       expect(response.status).to eq(200)

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -225,4 +225,29 @@ describe 'job_definitions' do
       end
     end
   end
+
+  describe 'DELETE /v1/definitions/:id' do
+    let!(:definition) do
+      create(:job_definition, script: 'noop:')
+    end
+
+    before do
+      create_list(:job_definition, 2, script: 'noop:')
+    end
+
+    it 'deletes the job' do
+      expect do
+        delete "/v1/definitions/#{definition.id}", env: env
+      end.to change { Kuroko2::JobDefinition.count }.by(-1)
+      expect(Kuroko2::JobDefinition.where(id: definition.id)).to be_empty
+      expect(response.status).to eq(204)
+    end
+
+    it 'errors when trying to delete a job_definition that does not exist' do
+      definition.destroy
+
+      delete "/v1/definitions/#{definition.id}", env: env
+      expect(response.status).to eq(404)
+    end
+  end
 end

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -80,7 +80,6 @@ describe 'job_definitions' do
           suspended: false,
           prevent_multi: 1,
           hipchat_additional_text: "",
-          text_tags: "",
           api_allowed: 1,
           slack_channel: "",
           webhook_url: "",
@@ -101,6 +100,60 @@ describe 'job_definitions' do
       end
     end
 
+    context 'with tags' do
+      let(:params) do
+        {
+          name: "test",
+          description: "description",
+          script: "noop:",
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          tags: ["awesome", "sauce"],
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+          user_id: [user.id],
+        }
+      end
+
+      it 'creates the new tags' do
+        expect {
+          post "/v1/definitions", params: params, env: env
+        }.to change {
+          Kuroko2::Tag.count
+        }.by(2)
+
+        expect(response.status).to eq(201)
+        expect(result['name']).to eq(params[:name])
+        expect(result['description']).to eq(params[:description])
+        expect(result['script']).to eq(params[:script])
+        expect(result['tags']).to eq ["awesome", "sauce"]
+      end
+
+      context 'with a preexisiting tag' do
+        before do
+          Kuroko2::Tag.create(name: "awesome")
+        end
+
+        it 'only creates the tag the does not exist' do
+          expect {
+            post "/v1/definitions", params: params, env: env
+          }.to change {
+            Kuroko2::Tag.count
+          }.by(1)
+
+          expect(result['name']).to eq(params[:name])
+          expect(result['description']).to eq(params[:description])
+          expect(result['script']).to eq(params[:script])
+          expect(result['tags']).to eq ["awesome", "sauce"]
+        end
+      end
+    end
+
     context 'with invalid parameters' do
       let(:params) do
         {
@@ -112,7 +165,6 @@ describe 'job_definitions' do
           suspended: false,
           prevent_multi: 1,
           hipchat_additional_text: "",
-          text_tags: "",
           api_allowed: 1,
           slack_channel: "",
           webhook_url: "",
@@ -165,7 +217,6 @@ describe 'job_definitions' do
           suspended: false,
           prevent_multi: 1,
           hipchat_additional_text: "",
-          text_tags: "",
           api_allowed: 1,
           slack_channel: "",
           webhook_url: "",
@@ -175,6 +226,36 @@ describe 'job_definitions' do
       it 'updates a definition' do
         put "/v1/definitions/#{definition.id}", params: params, env: env
         expect(response.status).to eq(204)
+      end
+    end
+
+    context 'with tags' do
+      let(:params) do
+        {
+          name: "test",
+          description: "description",
+          script: "echo: Hello",
+          notify_cancellation: 1,
+          hipchat_room: "",
+          hipchat_notify_finished: 1,
+          suspended: false,
+          prevent_multi: 1,
+          hipchat_additional_text: "",
+          api_allowed: 1,
+          slack_channel: "",
+          webhook_url: "",
+          tags: ["new-tag"]
+        }
+      end
+
+      it 'adds the tags' do
+        expect {
+          put "/v1/definitions/#{definition.id}", params: params, env: env
+        }.to change {
+          Kuroko2::Tag.count
+        }.by(1)
+        expect(response.status).to eq(204)
+        expect(definition.tags.pluck(:name)).to eq ["new-tag"]
       end
     end
 
@@ -190,7 +271,6 @@ describe 'job_definitions' do
           suspended: false,
           prevent_multi: 1,
           hipchat_additional_text: "",
-          text_tags: "",
           api_allowed: 1,
           slack_channel: "",
           webhook_url: "",
@@ -215,7 +295,6 @@ describe 'job_definitions' do
           suspended: false,
           prevent_multi: 1,
           hipchat_additional_text: "",
-          text_tags: "",
           api_allowed: 1,
           slack_channel: "",
           webhook_url: "",


### PR DESCRIPTION
# Background

In Cookpad global we are used to managing cron jobs using a configuration as code tool https://github.com/javan/whenever. In order to ease the transition to running such scheduled tasks with kuroko2 we are going to build a similar tool to manage kuroko2 job definitions.

# Changes

We have extended the API slightly to support the index and delete actions... to expose tags (that we will use for project name-spacing on shared kuroko2 instances) and to expose and set job_schedules.

FYI: @cookpad/infra

Please let me know if there is anything I can do to help with reviewing this change... or if you need any additional background!