### PR TITLE
Update name validation to match db constraint

### DIFF
--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -62,7 +62,7 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
   }
 
 
-  validates :name, length: { maximum: 40 }, presence: true
+  validates :name, length: { maximum: 180 }, presence: true
   validates :description, presence: true
   validates :script, presence: true
   validate :script_syntax


### PR DESCRIPTION
40 characters is too restrictive for our use, as we are giving job
definitions the same name as rake tasks that they are running.

I have increased the limit to 180 to match the size of the database
column.