### PR TITLE
Increase max length of :slack_channel to 81

### DIFF
--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -69,7 +69,7 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
   validate :validate_number_of_admins
   validates :hipchat_additional_text, length: { maximum: 180 }
   validates :slack_channel,
-    length: { maximum: 22, too_long: ' is too long (maximum is 21 characters without `#` symbol at the head)' },
+    length: { maximum: 81, too_long: ' is too long (maximum is 80 characters without `#` symbol at the head)' },
     format: {
       with: /\A#[^\.\s]+\z/, allow_blank: true,
       message: ' must start with # and must not include any dots or spaces'


### PR DESCRIPTION
ref: https://slackhq.com/new-slack-features-search-calls-channels

> We’re extending the maximum length of channel names—from 21 to a whopping 80 characters.

as the article mentions, we can now name slack channel with up to 80 chars. 📝 

Can we increase the max length of slack_channel attribute on JobuDefinition too?

please review  👀 🙏 @cookpad/infra 