### PR TITLE
Add kuroko2_manifest.js for sprockets 4

### DIFF
--- a/app/assets/config/kuroko2_manifest.js
+++ b/app/assets/config/kuroko2_manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images/kuroko2
+//= link_directory ../javascripts/kuroko2 .js
+//= link_directory ../stylesheets/kuroko2 .css

--- a/app_template.rb
+++ b/app_template.rb
@@ -76,6 +76,10 @@ scheduler: ./bin/rails runner Kuroko2::Servers::JobScheduler.new.run
 processor: ./bin/rails runner Kuroko2::Servers::WorkflowProcessor.new.run
 EOF
 
+inject_into_file "app/assets/config/manifest.js", after: "//= link_directory ../stylesheets .css\n" do
+  "//= link kuroko2_manifest.js"
+end
+
 run 'bundle install'
 rake 'kuroko2:install:migrations'
 rake 'db:create'


### PR DESCRIPTION
In sprockets 4, we need to specify assets directories with `manifest.js`. So I added `kuroko2_manifest.js` to specify assets directories of kuroko2 and added a link to the template.

ref: https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs

@cookpad/infra please review.