### PR TITLE
App template makes an encoding that does not exist when using Rails 6

### DIFF
--- a/app_template.rb
+++ b/app_template.rb
@@ -4,7 +4,7 @@ gsub_file 'Gemfile', /^gem 'turbolinks'.+/, ""
 gsub_file 'Gemfile', /^gem 'jbuilder'.+/, ""
 gsub_file 'Gemfile', /^gem 'jquery-rails'.+/, ""
 gsub_file 'Gemfile', /^gem 'coffee-rails'.+/, ""
-gsub_file 'config/database.yml', "encoding: utf8", "encoding: utf8mb4"
+gsub_file 'config/database.yml', /encoding: utf8$/, "encoding: utf8mb4"
 
 gem 'kuroko2'
 


### PR DESCRIPTION
The default encoding for MySQL is `utf8mb4` at Rails 6.
So nothing needs to replace an encoding.