### PR TITLE
Remove `halt_callback_chains_on_return_false` config from test app

### DIFF
--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -18,6 +18,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
ref: https://github.com/cookpad/kuroko2/pull/112

This option is no longer available on Rails 5.2 or newer, so we should remove the option to update Rails to v5.2.

This option changes Active Record's callbacks behavior if a callback returns false.
But I've confirmed the all AR callbacks in this project don't return false.
So we can remove this option safely.

By the way, I use kuroko2 with `halt_callback_chains_on_return_false = false` over 3 years, and we don't have any problem related to this option.


---

I got other errors by tests with Rails 5.2, so this pull request doesn't revert #112.