### PR TITLE
Replace meaningless `after_save` + `on: :create` with `after_create`

### DIFF
--- a/app/models/kuroko2/job_definition.rb
+++ b/app/models/kuroko2/job_definition.rb
@@ -35,7 +35,7 @@ class Kuroko2::JobDefinition < Kuroko2::ApplicationRecord
 
   before_destroy :confirm_active_instances
   after_initialize :set_default_values
-  after_save :create_default_memory_expectancy, on: :create
+  after_create :create_default_memory_expectancy
 
   scope :ordered, -> { order(:id) }
   scope :tagged_by, ->(tags) {


### PR DESCRIPTION
When I tried to use Kuroko2 on Rails 6, I got the following error.

```
ArgumentError:                                                                                            
  Unknown key: :on. Valid keys are: :if, :unless, :prepend                                                
# ./app/models/kuroko2/job_definition.rb:38:in `<class:JobDefinition>' 
```


Because `on:` keyword does nothing with `after_save` method. It doesn't cause any error with Rails 5.x, but Rails 6 has more strict validation. So the meaningless `on:` keyword raises an error.


So this pull request replaces it with `after_create` to fix the error. I think it is the expected callback method.



ref: https://github.com/rails/rails/issues/35329


By the way, this pull request doesn't guarantee Kuroko2 works with Rails 6 correctly.
I've confirmed this patch fixes the error, but I gave up to upgrade Rails to 6 after the confirmation. So maybe it still has other problems with Rails 6.



