### PR TITLE
Delete tokens of the job instance only

### DIFF
--- a/lib/autoload/kuroko2/workflow/engine.rb
+++ b/lib/autoload/kuroko2/workflow/engine.rb
@@ -141,7 +141,7 @@ module Kuroko2
         token.job_instance.logs.error("(token #{token.uuid}) #{message}")
         token.job_instance.touch(:canceled_at)
 
-        Token.where(job_definition: token.job_definition).delete_all
+        Token.where(job_instance: token.job_instance).delete_all
         token.job_instance.logs.warn("(token #{token.uuid}) This job is canceled.")
 
         Kuroko2.logger.error(message)


### PR DESCRIPTION
When a job definition allows "parallel execution", there could be
multiple running job instances. When EngineError (like syntax error in
job script) happens in one job instance, the tokens of other job
instances must not be deleted.