### PR TITLE
Use POST request for Google OAuth2

### DIFF
--- a/app/views/kuroko2/sessions/new.html.slim
+++ b/app/views/kuroko2/sessions/new.html.slim
@@ -14,7 +14,7 @@ html.bg-black
       .body
         p.lead Please sign in with Google account.
         .text-center
-          a.btn.btn-social.btn-google-plus href=auth_path("google_oauth2", state: params[:return_to])
+          = button_to auth_path("google_oauth2", state: params[:return_to]), class: 'btn btn-social btn-google-plus' do
             i.fa.fa-google-plus
             span Sign in with Google
       .footer


### PR DESCRIPTION
This patch replaces a link (`<a>`) to Google OAuth2 with `<form>` and `<button>` to use POST request.


It is the recommended way by omniauth documentation. see https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284

> If the use of GET requests to /auth/:provider is essential for your application (for example, if you are ever redirecting to /auth/:provider as part of an authentication process), then you will need to put together a more involved solution for your specific needs. This may mean redirecting to a standard log-in screen which includes link_to 'Log in', '/auth/:provider', method: :post or another POST/form-based approach (like button_to).



This change is required to use omniauth-rails_csrf_protection gem securely because the gem doesn't allow GET request for `/auth/:provider` by default.


I've confirmed that the sign-in button works with this patch.