### PR TITLE
Relax omniauth-google-oauth2 dependency to allow omniauth v2

### DIFF
--- a/kuroko2.gemspec
+++ b/kuroko2.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-store', '~> 0.0.4'
   s.add_dependency 'dotenv-rails', '~> 0.11.1'
   s.add_dependency 'serverengine', '~> 1.5.7'
-  s.add_dependency 'omniauth-google-oauth2', '~> 0.6.0'
+  s.add_dependency 'omniauth-google-oauth2'
 
   s.add_dependency 'html-pipeline'
   s.add_dependency 'commonmarker', '>= 0.17.8'


### PR DESCRIPTION
Omniauth gem v2 has been released and it contains a security fix.
https://github.com/omniauth/omniauth/releases/tag/v2.0.0

But the dependency reject using omniauth v2 because
omniauth-google-oauth2 gem is pinned to v0.6 and it requires omniauth
gem `< 2`.

So this patch relaxes the version restriction.


Personally I think no version restriction is better than using a restriction such as `< 3`.
The restriction blocks upgrading gem but the upgrading doesn't break anything in most cases. So I just removed the restriction. 