### PR TITLE
Reuse vis.Timeline object to remove flicker 

### DIFF
--- a/app/assets/javascripts/kuroko2/job_timelines.js.coffee
+++ b/app/assets/javascripts/kuroko2/job_timelines.js.coffee
@@ -15,7 +15,7 @@ $ ->
     new vis.Timeline(
       container.get(0),
       response.data,
-      $.extend(options, {start: response.start_at, end: response.end_at})
+      $.extend(options, {start: response.start, end: response.end})
     )
 
   $.get(datasetPath, callback)

--- a/app/assets/javascripts/kuroko2/job_timelines.js.coffee
+++ b/app/assets/javascripts/kuroko2/job_timelines.js.coffee
@@ -9,14 +9,18 @@ $ ->
     order: (a, b) ->
       return a.end - b.end
   }
+  timeline = null
 
   callback = (response) ->
-    container.empty()
-    new vis.Timeline(
-      container.get(0),
-      response.data,
-      $.extend(options, {start: response.start, end: response.end})
-    )
+    if timeline == null
+      timeline = new vis.Timeline(
+        container.get(0),
+        response.data,
+        $.extend(options, {start: response.start, end: response.end})
+      )
+    else
+      timeline.setItems(response.data)
+      timeline.setOptions({start: response.start, end: response.end})
 
   $.get(datasetPath, callback)
   setInterval ->


### PR DESCRIPTION
This patch improves user experience on /job_timelines page by removing flicker during auto-reload.