### PR TITLE
Use mysql:8.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run test with Ruby ${{ matrix.ruby }}
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: kuroko2_root
           MYSQL_USER: kuroko2

--- a/spec/requests/api/job_definitions_spec.rb
+++ b/spec/requests/api/job_definitions_spec.rb
@@ -204,7 +204,7 @@ describe 'job_definitions' do
         expect(result['name']).to eq(params[:name])
         expect(result['description']).to eq(params[:description])
         expect(result['script']).to eq(params[:script])
-        expect(result['cron']).to eq(params[:cron])
+        expect(result['cron']).to match_array(params[:cron])
       end
 
       context 'an invalid schedule' do


### PR DESCRIPTION
We're going to upgrade our Kuroko2 deployment to use MySQL 8.0-compatible database cluster. This PR updates MySQL version used in CI to prepare for that. I confirmed specs passing locally with MySQL 8.0 (with changes in #156).

@cookpad/infra could you please review?